### PR TITLE
Prepare builder for behavior data

### DIFF
--- a/nsds_lab_to_nwb/common/data_scanner.py
+++ b/nsds_lab_to_nwb/common/data_scanner.py
@@ -1,19 +1,39 @@
 import os
 from nsds_lab_to_nwb.common.dataset import Dataset
 
+
 class DataScanner():
     def __init__(self, animal_name, block,
                  data_path: str = '',
-                 stim_path: str = '',
-                 htk_path: str = '',
-                 tdt_path: str = '',
                  ):
         self.data_path = data_path
         self.animal_name = animal_name
         self.block = block
-        self.stim_path = stim_path
-        self.htk_path = htk_path
-        self.tdt_path = tdt_path
+
+    def extract_dataset(self):
+        # should be implemented for the specific experiment type
+        raise NotImplementedError
+
+    def add_block_subdir(self, path):
+        return os.path.join(path, self.animal_name, 
+                            self.animal_name + '_' + self.block + '/')
+
+
+class AuditoryDataScanner(DataScanner):
+    def __init__(self, animal_name, block,
+                 data_path: str = '',
+                 stim_path=None,
+                 htk_path=None,
+                 tdt_path=None,
+                 ):
+        DataScanner.__init__(self, animal_name, block, data_path=data_path)
+
+        # detect relevant subdirectories for auditory dataset
+        # use default subdirectory name, or override by input
+        # ******* TODO: confirm/standardize subdirectory structure *******
+        self.stim_path = stim_path or os.path.join(self.data_path, 'Stimulus/')
+        self.htk_path = htk_path or os.path.join(self.data_path, 'RatArchive/')
+        self.tdt_path = tdt_path or os.path.join(self.data_path, 'TTankBackup/')
 
     def extract_dataset(self):
         raw_htk_path = self.__get_raw_htk_path()
@@ -37,6 +57,17 @@ class DataScanner():
     def __get_raw_tdt_path(self):
         return self.add_block_subdir(self.tdt_path)
 
-    def add_block_subdir(self, path):
-        return os.path.join(path, self.animal_name, 
-                            self.animal_name + '_' + self.block + '/')
+
+class BehaviorDataScanner(DataScanner):
+    def __init__(self, animal_name, block,
+                 data_path: str = '',
+                 video_path=None,
+                 ):
+        DataScanner.__init__(self, animal_name, block, data_path=data_path)
+                            
+        # TODO: collect and pass relevant subdirectories. maybe video_path?
+        self.video_path = video_path or os.path.join(self.data_path, 'Video/') # <<<< replace accordingly
+
+    def extract_dataset(self):
+        # TODO for behavior (reaching) data
+        raise NotImplementedError

--- a/nsds_lab_to_nwb/metadata/metadata_manager.py
+++ b/nsds_lab_to_nwb/metadata/metadata_manager.py
@@ -25,10 +25,12 @@ class MetadataManager:
         if self.animal_name is None:
             self.animal_name = self.block_name.split('_')[0]
 
-        self.yaml_lib_path = os.path.join(self.library_path, self.experiment_type,
-                                'yaml/')
-        self.stim_lib_path = os.path.join(self.library_path, self.experiment_type,
-                                'configs_legacy/mars_configs/') # <<<< should move to a better subfolder
+        # paths to metadata/stimulus library
+        self.yaml_lib_path = os.path.join(self.library_path, self.experiment_type, 'yaml/')
+        if self.experiment_type == 'auditory':
+            self.stim_lib_path = os.path.join(self.library_path, self.experiment_type,
+                    'configs_legacy/mars_configs/') # <<<< should move to a better subfolder
+
         self.metadata = self.extract_metadata()
 
     def read_block_metadata_file(self, default_experiment_type=_DEFAULT_EXPERIMENT_TYPE):
@@ -53,6 +55,8 @@ class MetadataManager:
                 self.expand_device(metadata, value)
                 continue
             if key == 'stimulus':
+                if self.experiment_type != 'auditory':
+                    raise ValueError('experiment type mismatch')
                 self.expand_stimulus(metadata, value)
                 continue
             # else:


### PR DESCRIPTION
The pipeline now requires a new variable `experiment_type`, which takes a string value, either "auditory" or "behavior".

This variable `experiment_type` will be specified as part of the block metadata file (not yet implemented). For now, the default `experiment_type` is set to "auditory" if the block metadata file does not have the field.

Then {DataScanner, MetadataManager, NWBBuilder} diverge at various places according to the experiment type.