### PR TITLE
Test htk

### DIFF
--- a/nsds_lab_to_nwb/nwb_builder.py
+++ b/nsds_lab_to_nwb/nwb_builder.py
@@ -85,7 +85,7 @@ class NWBBuilder:
         else:
             raise ValueError('unknown experiment type')
 
-    def build(self, use_htk=False, process_stim=True):
+    def build(self, process_stim=True):
         '''Build NWB file content.
 
         Parameters
@@ -128,7 +128,7 @@ class NWBBuilder:
         electrode_table_regions = self.electrodes_originator.make(nwb_content)
 
         if self.experiment_type == 'auditory':
-            if use_htk:
+            if self.use_htk:
                 # legacy pipeline
                 self.htk_originator.make(nwb_content, electrode_table_regions)
             else:

--- a/nsds_lab_to_nwb/nwb_builder.py
+++ b/nsds_lab_to_nwb/nwb_builder.py
@@ -41,7 +41,8 @@ class NWBBuilder:
             block: str,
             nwb_metadata: MetadataManager,
             out_path: str = '',
-            session_start_time = _DEFAULT_SESSION_START_TIME
+            session_start_time = _DEFAULT_SESSION_START_TIME,
+            use_htk = False
     ):
         self.data_path = data_path
         self.animal_name = animal_name
@@ -49,6 +50,7 @@ class NWBBuilder:
         self.metadata = nwb_metadata.metadata
         self.out_path = out_path
         self.session_start_time = session_start_time
+        self.use_htk = use_htk
 
         self.experiment_type = self.metadata['experiment_type'] # now required
 
@@ -72,8 +74,10 @@ class NWBBuilder:
         self.electrode_groups_originator = ElectrodeGroupsOriginator(self.metadata)
         self.electrodes_originator = ElectrodesOriginator(self.metadata)
         if self.experiment_type == 'auditory':
-            self.htk_originator = HtkOriginator(self.dataset, self.metadata)
-            self.tdt_originator = TdtOriginator(self.dataset, self.metadata)
+            if self.use_htk:
+                self.htk_originator = HtkOriginator(self.dataset, self.metadata)
+            else:
+                self.tdt_originator = TdtOriginator(self.dataset, self.metadata)
             self.stimulus_originator = StimulusOriginator(self.dataset, self.metadata)
         elif self.experiment_type == 'behavior':
             # TODO: implement originators as needed

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -90,7 +90,7 @@ class TestCase_Build_NWB(unittest.TestCase):
                         use_htk=True
                         )
         # build the NWB file content
-        nwb_content = nwb_builder.build(process_stim=True, use_htk=True)
+        nwb_content = nwb_builder.build(process_stim=True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import unittest
 import sys
+from pynwb import NWBHDF5IO
 sys.path.insert(0, '.')
 
 from nsds_lab_to_nwb.nwb_builder import NWBBuilder
@@ -14,14 +15,14 @@ USER_HOME = os.path.expanduser("~")
 class TestCase_Build_NWB(unittest.TestCase):
 
     # raw data path
-    data_path = '/home/jhermiz/data/hackathon20201201/RatArchive/'
+    data_path = '/home/jhermiz/data/hackathon20201201/'
 
     # new base?
     # data_path_tdt = '/clusterfs/NSDS_data/hackathon20201201/TTankBackup/'
 
     # output path (this will not be used)
     out_path = os.path.join(USER_HOME, 'Data/nwb_test/')
-
+    
     def test_build_nwb_case1_old_data(self):
         ''' build NWB but do not write file to disk '''
         animal_name = 'R56'
@@ -65,24 +66,34 @@ class TestCase_Build_NWB(unittest.TestCase):
                         )
         # build the NWB file content
         nwb_content = nwb_builder.build(process_stim=False)
+        
 
     def test_build_nwb_case3_htk(self):
         ''' build NWB but do not write file to disk '''
         animal_name = 'R56'
         block = 'B13'
         block_name = '{}_{}'.format(animal_name, block)
+        block_metadata_path = os.path.join(PWD, f'../yaml/{animal_name}/{animal_name}_{block}.yaml')
+        library_path = os.path.join(USER_HOME, 'software/NSDSLab-NWB-metadata/')
 
+        # collect metadata needed to build the NWB file
+        nwb_metadata = MetadataManager(block_name=block_name,
+                                       block_metadata_path=block_metadata_path,
+                                       library_path=library_path)
         # create a builder for the block
         nwb_builder = NWBBuilder(
                         animal_name=animal_name,
                         block=block,
                         data_path=self.data_path,
-                        out_path=self.out_path
+                        out_path=self.out_path,
+                        nwb_metadata=nwb_metadata,
+                        use_htk=True
                         )
         # build the NWB file content
-        nwb_content = nwb_builder.build(use_htk=True, process_stim=False)
-
-
+        nwb_content = nwb_builder.build(process_stim=True, use_htk=True)
+        io = NWBHDF5IO('test_htk.nwb', 'w')
+        io.write(nwb_content)
+        io.close()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -91,9 +91,6 @@ class TestCase_Build_NWB(unittest.TestCase):
                         )
         # build the NWB file content
         nwb_content = nwb_builder.build(process_stim=True, use_htk=True)
-        io = NWBHDF5IO('test_htk.nwb', 'w')
-        io.write(nwb_content)
-        io.close()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -1,6 +1,8 @@
 import os
 import numpy as np
 import unittest
+import sys
+sys.path.insert(0, '.')
 
 from nsds_lab_to_nwb.nwb_builder import NWBBuilder
 from nsds_lab_to_nwb.metadata.metadata_manager import MetadataManager
@@ -12,7 +14,7 @@ USER_HOME = os.path.expanduser("~")
 class TestCase_Build_NWB(unittest.TestCase):
 
     # raw data path
-    data_path = '/clusterfs/NSDS_data/hackathon20201201/'
+    data_path = '/home/jhermiz/data/hackathon20201201/RatArchive/'
 
     # new base?
     # data_path_tdt = '/clusterfs/NSDS_data/hackathon20201201/TTankBackup/'
@@ -63,6 +65,24 @@ class TestCase_Build_NWB(unittest.TestCase):
                         )
         # build the NWB file content
         nwb_content = nwb_builder.build(process_stim=False)
+
+    def test_build_nwb_case3_htk(self):
+        ''' build NWB but do not write file to disk '''
+        animal_name = 'R56'
+        block = 'B13'
+        block_name = '{}_{}'.format(animal_name, block)
+
+        # create a builder for the block
+        nwb_builder = NWBBuilder(
+                        animal_name=animal_name,
+                        block=block,
+                        data_path=self.data_path,
+                        out_path=self.out_path
+                        )
+        # build the NWB file content
+        nwb_content = nwb_builder.build(use_htk=True, process_stim=False)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -15,7 +15,7 @@ USER_HOME = os.path.expanduser("~")
 class TestCase_Build_NWB(unittest.TestCase):
 
     # raw data path
-    data_path = '/home/jhermiz/data/hackathon20201201/'
+    data_path = '/clusterfs/NSDS_data/hackathon20201201/'
 
     # new base?
     # data_path_tdt = '/clusterfs/NSDS_data/hackathon20201201/TTankBackup/'


### PR DESCRIPTION
This addresses issue #21 HTK --> NWB now works. Previously, `NWBBuilder` called `tdt_orignator` even though htk data was passed. Created a `use_htk` optional arg to stop that from happening. Wrote test case `test_build_nwb_case3_htk` and compared new nwb to past nwb and they looked the same across various spot checks.