### PR TITLE
Added ods (open source eqv of xlsx) reader

### DIFF
--- a/docs/source/nsds_lab_to_nwb/nsds_lab_to_nwb.metadata.rst
+++ b/docs/source/nsds_lab_to_nwb/nsds_lab_to_nwb.metadata.rst
@@ -5,3 +5,8 @@ nsds\_lab\_to\_nwb.metadata API
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. automodule:: nsds_lab_to_nwb.metadata.exp_note_reader
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - pynwb
   - pyyaml
   - imageio
-  - pandas=0.25.3
+  - pandas
 
   - pip:
     - tdt

--- a/environment.yml
+++ b/environment.yml
@@ -21,9 +21,11 @@ dependencies:
   - pynwb
   - pyyaml
   - imageio
+  - pandas
 
   - pip:
     - tdt
+    - odfpy
     - sphinx-rtd-theme
     - sphinx-gallery
     - -rrequirements.txt

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - pynwb
   - pyyaml
   - imageio
-  - pandas
+  - pandas=0.25.3
 
   - pip:
     - tdt

--- a/nsds_lab_to_nwb/metadata/exp_note_reader.py
+++ b/nsds_lab_to_nwb/metadata/exp_note_reader.py
@@ -33,13 +33,14 @@ class ExpNoteReader():
         
         no_file_flag = False
         # force input if specified
-        if self.input_format != 'gs':
-            path_contents = os.listdir(path)
-            for file in path_contents:
-                if file.endswith('.' + self.input_format):
-                    self.file.append(file)
-            if len(self.file) == 0:
-                no_file_flag = True
+        if self.input_format is not None:
+            if self.input_format != 'gs':
+                path_contents = os.listdir(path)
+                for file in path_contents:
+                    if file.endswith('.' + self.input_format):
+                        self.file.append(file)
+                if len(self.file) == 0:
+                    no_file_flag = True
         else:
         # autodetect input format
             if path.startswith('http'):

--- a/nsds_lab_to_nwb/metadata/exp_note_reader.py
+++ b/nsds_lab_to_nwb/metadata/exp_note_reader.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import os
-import yaml
 from nsds_lab_to_nwb.utils import split_block_folder
 from nsds_lab_to_nwb.common.io import write_yaml
 
@@ -131,13 +130,13 @@ class ExpNoteReader():
                                skiprows=1, 
                                names=['a', 'values', 'b', 'c'],
                                index_col=1,
-                               dtype=type('hello'))
+                               dtype=str)
         
         
         raw_block = pd.read_csv(block_path_file,
                                      delimiter=',',
                                      header=2,
-                                     dtype=type('hello'))   
+                                     dtype=str)   
         self._raw_meta = raw_meta
         self._raw_block = raw_block
     
@@ -145,16 +144,13 @@ class ExpNoteReader():
         """Read ods
         """
         path_file = os.path.join(self.path, self.file[0])
-        raw_meta = pd.read_excel(path_file, sheet_name='MetaData',                                  
-                               delimiter=',',
-                               index_col=1,
+        raw_meta = pd.read_excel(path_file, sheet_name='MetaData',index_col=1,
                                names=['a', 'b', 'values', 'c', 'd'],
-                               dtype=type('hello'), 
+                               dtype=str, 
                                engine='odf')
-        raw_block = pd.read_excel(path_file, sheet_name='BlockData',                                  
-                                     delimiter=',',
+        raw_block = pd.read_excel(path_file, sheet_name='BlockData', 
                                      header=2,
-                                     dtype=type('hello'),
+                                     dtype=str,
                                      engine='odf')
         self._raw_meta = raw_meta
         self._raw_block = raw_block
@@ -210,4 +206,3 @@ class ExpNoteReader():
             self.read_input()
             self.merge_meta_block()
         return self.nsds_meta
-

--- a/nsds_lab_to_nwb/metadata/exp_note_reader.py
+++ b/nsds_lab_to_nwb/metadata/exp_note_reader.py
@@ -74,10 +74,11 @@ class ExpNoteReader():
         """
         raw_meta = self._raw_meta
         raw_block = self._raw_block
+        
         #clean up raw_meta
         raw_meta = raw_meta.iloc[:, 1]
-        raw_meta.dropna(inplace=True)
-        self.meta_df = raw_meta
+        good_indices = raw_meta.index.dropna()
+        raw_meta = raw_meta.loc[good_indices]       
         
         #clean up raw_block
         for idx, row in raw_block.iterrows():
@@ -92,8 +93,9 @@ class ExpNoteReader():
                 raw_block.drop(column, axis=1, inplace=True)
         raw_block = raw_block[:max_row]
         raw_block.dropna(axis=1, how='all', inplace=True)
-        self.block_df = raw_block
         
+        self.meta_df = raw_meta
+        self.block_df = raw_block        
     
     def read_csvs(self):
         """Read csv files
@@ -196,3 +198,7 @@ class ExpNoteReader():
             self.read_input()
             self.merge_meta_block()
         return self.nsds_meta
+
+path = '/home/jhermiz/Desktop/test'
+reader = ExpNoteReader(path, 'RVG16_B01')
+reader.dump_yaml(write_path=path)


### PR DESCRIPTION
I added a spreadsheet reader so that the experimentalist would only need to download one file (instead of 2 separate csvs). Originally I planned onwriting an xlsx reader, but I decided to go with a less propierty, open source ods format, which is supported by Google Drive. I checked that the yaml it dumps is almost the same, but there are some minor differences. We should test whether the yaml created from the ods reader causes the metadata manager to break.