### PR TITLE
[WIP] Add stim aliases

### DIFF
--- a/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
@@ -20,14 +20,14 @@ tone150:
     parameter_path: 'Tone150/freq_resp_area_stimulus_signal_flo500Hz_fhi32000Hz_nfreq30_natten1_nreps150_fs96000.mat'
 
 timit:
-    alt_names: []
+    alt_names: ['Timit998']
     description: ''
     audio_path: 'TIMIT/timit998s.wav'
     marker_path: 'TIMIT/timit998m.wav.wav'
     parameter_path: 'TIMIT/timit998/timit998.mat'
 
 tone:
-    alt_names: []
+    alt_names: ['Full tone']
     description: ''
     audio_path: 'Tone/stimulus_signal_03202013.wav'
     marker_path: 'Tone/stimulus_trigger_03202013.wav'
@@ -41,8 +41,22 @@ wn2:
     parameter_path: ''
 
 dmr:
-    alt_names: []
+    alt_names: ['Ripple']
     description: ''
     audio_path: 'DMR/dmr-500flo-40000fhi-4SM-40TM-40db-96khz-48DF-15min.wav'
     marker_path: 'DMR/trig-dmr-500flo-40000fhi-4SM-40TM-40db-96khz-48DF-15min.wav'
+    parameter_path: ''
+
+tone_diagnostic:
+    alt_names: ['Tone diagnostic']
+    description: '' #Vanessa can you please add a description, copy files to catscan and add paths (if the files exist)
+    audio_path: ''
+    marker_path: ''
+    parameter_path: ''
+
+baseline:
+    alt_names: []
+    description: 'No stimulus'
+    audio_path: ''
+    marker_path: ''
     parameter_path: ''

--- a/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
@@ -55,7 +55,7 @@ tone_diagnostic:
     parameter_path: ''
 
 baseline:
-    alt_names: []
+    alt_names: ['Baseline']
     description: 'No stimulus'
     audio_path: ''
     marker_path: ''

--- a/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
@@ -22,8 +22,8 @@ tone150:
 timit:
     alt_names: ['Timit998']
     description: ''
-    audio_path: 'TIMIT/timit998s.wav'
-    marker_path: 'TIMIT/timit998m.wav.wav'
+    audio_path: 'TIMIT/timit998/timit998s.wav'
+    marker_path: 'TIMIT/timit998/timit998m.wav'
     parameter_path: 'TIMIT/timit998/timit998.mat'
 
 tone:


### PR DESCRIPTION
# Description and related issues

- Updated `list_of_stimuli.yaml` with new aliases and fixed timit998 paths. 
- Discovered new possible bug with timit998 stimuli as reported a new issue #70 

Addressing #72


# Checklist:

- [ ] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory
- [ ] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [ ] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [ ] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory
