### PR TITLE
Added resample and description code

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,3 +31,4 @@ dependencies:
     - sphinx-rtd-theme
     - sphinx-gallery
     - pytest-xdist
+    - process_nwb

--- a/nsds_lab_to_nwb/components/neural_data/neural_data_originator.py
+++ b/nsds_lab_to_nwb/components/neural_data/neural_data_originator.py
@@ -3,15 +3,18 @@ from pynwb.ecephys import ElectricalSeries
 
 from nsds_lab_to_nwb.components.htk.htk_reader import HTKReader
 from nsds_lab_to_nwb.components.tdt.tdt_reader import TDTReader
-
+from process_nwb.resample import resample
 
 logger = logging.getLogger(__name__)
 
 
 class NeuralDataOriginator():
-    def __init__(self, dataset, metadata):
+    def __init__(self, dataset, metadata, resample_flag=True):
         self.dataset = dataset      # this should have all relavant paths
         self.metadata = metadata    # this should have all relevant metadata
+        self.resample_flag = resample_flag
+        self.hardware_rate = None
+        self.resample_rate = None
 
         if hasattr(self.dataset, 'htk_mark_path'):
             logger.info('Using HTK')
@@ -19,6 +22,34 @@ class NeuralDataOriginator():
         else:
             logger.info('Using TDT')
             self.neural_data_reader = TDTReader(self.dataset.tdt_path)
+            
+    def make_description(self, device_name):       
+            description = self.metadata['experiment_description']
+            description += '. Recordings from {0:s} sampled at {1:f} Hz.'.format(device_name, 
+                                                        self.hardware_rate)
+            if self.resample_flag:
+                description += ' Then resampled down to {0:d} Hz'.format(int(self.resample_rate))
+            return description
+    
+    def resample(self, data):        
+        #only resample if rate is not at nearest kHz
+        rate = self.hardware_rate
+        if (rate/1000 % 1) > 0:            
+            new_freq = (rate//1000)*1000
+            new_data = resample(data, new_freq, rate)
+            self.resample_rate = new_freq
+            return new_data
+        else:
+            #no need to resample, already at nearest kHz
+            self.resample_flag = False 
+            return data
+        
+    def _get_rate(self):
+        if self.resample_rate is None:
+            rate = self.hardware_rate
+        else:
+            rate = self.resample_rate
+        return rate*1.0
 
     def make(self, nwb_content, electrode_table_regions):
         for device_name, dev_conf in self.metadata['device'].items():
@@ -28,13 +59,23 @@ class NeuralDataOriginator():
             data, metadata = self.neural_data_reader.get_data(stream=device_name, dev_conf=dev_conf)
             if data is None:
                 logger.info(f'No data availble for {device_name}. Skipping...')
-            else:
+            else:    
+                
+                #resample data
+                self.hardware_rate = metadata['sample_rate']
+                if self.resample_flag:
+                    data = self.resample(data)                
+                
+                #make description
+                description = self.make_description(device_name)
+                
                 electrode_table_region = electrode_table_regions[device_name]
-                e_series = ElectricalSeries(name=device_name,
+                e_series = ElectricalSeries(name=device_name,                                            
                                             data=data,
                                             electrodes=electrode_table_region,
                                             starting_time=0.,
-                                            rate=metadata['sample_rate'],
+                                            rate=self._get_rate(),
+                                            description=description
                                             )
                 logger.info(f'Adding {device_name} data NWB...')
                 nwb_content.add_acquisition(e_series)

--- a/nsds_lab_to_nwb/components/neural_data/neural_data_originator.py
+++ b/nsds_lab_to_nwb/components/neural_data/neural_data_originator.py
@@ -22,34 +22,34 @@ class NeuralDataOriginator():
         else:
             logger.info('Using TDT')
             self.neural_data_reader = TDTReader(self.dataset.tdt_path)
-            
-    def make_description(self, device_name):       
-            description = self.metadata['experiment_description']
-            description += '. Recordings from {0:s} sampled at {1:f} Hz.'.format(device_name, 
-                                                        self.hardware_rate)
-            if self.resample_flag:
-                description += ' Then resampled down to {0:d} Hz'.format(int(self.resample_rate))
-            return description
-    
-    def resample(self, data):        
-        #only resample if rate is not at nearest kHz
+
+    def make_description(self, device_name):
+        description = self.metadata['experiment_description']
+        description += '. Recordings from {0:s} sampled at {1:f} Hz.'.format(device_name,
+                                                                             self.hardware_rate)
+        if self.resample_flag:
+            description += ' Then resampled down to {0:d} Hz'.format(int(self.resample_rate))
+        return description
+
+    def resample(self, data):
+        # only resample if rate is not at nearest kHz
         rate = self.hardware_rate
-        if (rate/1000 % 1) > 0:            
-            new_freq = (rate//1000)*1000
+        if (rate / 1000 % 1) > 0:
+            new_freq = (rate // 1000) * 1000
             new_data = resample(data, new_freq, rate)
             self.resample_rate = new_freq
             return new_data
         else:
-            #no need to resample, already at nearest kHz
-            self.resample_flag = False 
+            # no need to resample, already at nearest kHz
+            self.resample_flag = False
             return data
-        
+
     def _get_rate(self):
         if self.resample_rate is None:
             rate = self.hardware_rate
         else:
             rate = self.resample_rate
-        return rate*1.0
+        return rate * 1.0
 
     def make(self, nwb_content, electrode_table_regions):
         for device_name, dev_conf in self.metadata['device'].items():
@@ -59,18 +59,18 @@ class NeuralDataOriginator():
             data, metadata = self.neural_data_reader.get_data(stream=device_name, dev_conf=dev_conf)
             if data is None:
                 logger.info(f'No data availble for {device_name}. Skipping...')
-            else:    
-                
-                #resample data
+            else:
+
+                # resample data
                 self.hardware_rate = metadata['sample_rate']
                 if self.resample_flag:
-                    data = self.resample(data)                
-                
-                #make description
+                    data = self.resample(data)
+
+                # make description
                 description = self.make_description(device_name)
-                
+
                 electrode_table_region = electrode_table_regions[device_name]
-                e_series = ElectricalSeries(name=device_name,                                            
+                e_series = ElectricalSeries(name=device_name,
                                             data=data,
                                             electrodes=electrode_table_region,
                                             starting_time=0.,


### PR DESCRIPTION
# Description and related issues

I added resampling code a better description in `neural_data_originator` after the eseries creation was reorganized to happen in `neural_data_originator`. I did not test this on catscan, but I tested it on my local machine with RVG16_B01 and it runs without error and gives the expected output in two cases: when sample rate is fractional and when it's not.

There is a redundant PR (pre-reorg) on this that I will close shortly 

Closes #(issue number)

# Checklist:

- [ ] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory 
- [ ] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [ ] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [ ] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory

I test