### PR TITLE
formatting cleanup for the metadata subpackage

### DIFF
--- a/nsds_lab_to_nwb/metadata/exp_note_reader.py
+++ b/nsds_lab_to_nwb/metadata/exp_note_reader.py
@@ -3,6 +3,7 @@ import os
 from nsds_lab_to_nwb.utils import split_block_folder
 from nsds_lab_to_nwb.common.io import write_yaml
 
+
 class ExpNoteReader():
     """Class for parsing experiment notes
 
@@ -25,11 +26,11 @@ class ExpNoteReader():
         self.input_format = input_format
         self.block_folder = block_folder
         _, _, blockstr = split_block_folder(block_folder)
-        self.block_id = int(blockstr[1:])        
+        self.block_id = int(blockstr[1:])
         self.file = []
-        self._raw_meta = None 
+        self._raw_meta = None
         self._raw_block = None
-        
+
         no_file_flag = False
         # force input if specified
         if self.input_format is not None:
@@ -41,34 +42,34 @@ class ExpNoteReader():
                 if len(self.file) == 0:
                     no_file_flag = True
         else:
-        # autodetect input format
+            # autodetect input format
             if path.startswith('http'):
-                self.input_format = 'gs'            
-            else:        
+                self.input_format = 'gs'
+            else:
                 path_contents = os.listdir(path)
                 for file in path_contents:
-                    if file.endswith('.ods'): #priority for ods format
+                    if file.endswith('.ods'): # priority for ods format
                         self.input_format = 'ods'
                         self.file.append(file)
                         break
-                    if file.endswith('.xlsx'): 
+                    if file.endswith('.xlsx'):
                         self.input_format = 'xlsx'
                         self.file.append(file)
                         break
-                    if file.endswith('.csv'): 
+                    if file.endswith('.csv'):
                         self.input_format = 'csv'
-                        self.file.append(file)  
+                        self.file.append(file)
                 if len(self.file) == 0:
                     no_file_flag = True
-        
+
         if no_file_flag:
             raise FileNotFoundError
-        
+
         self.meta_df = None
         self.block_df = None
         self.meta_block_df = None
         self.nsds_meta = None
-    
+
     def read_input(self):
         """Read input
         """
@@ -77,89 +78,86 @@ class ExpNoteReader():
         elif self.input_format == 'xlsx':
             self.read_xlsx()
         elif self.input_format == 'gs':
-            self.read_gs()        
+            self.read_gs()
         elif self.input_format == 'ods':
             self.read_ods()
         self.parse_sheets()
-        
+
     def parse_sheets(self):
         """Parse raw dataframes read from experiment notes
         """
         raw_meta = self._raw_meta
         raw_block = self._raw_block
-        
-        #clean up raw_meta
+
+        # clean up raw_meta
         raw_meta = raw_meta.iloc[:, 1]
         good_indices = raw_meta.index.dropna()
-        raw_meta = raw_meta.loc[good_indices]       
-        
-        #clean up raw_block
+        raw_meta = raw_meta.loc[good_indices]
+
+        # clean up raw_block
         max_row = len(raw_block)
         for idx, row in raw_block.iterrows():
             try:
                 _ = int(row['block_id'])
-            except:
+            except ValueError:
                 max_row = idx
                 break
-            
+
         for column in raw_block.columns:
             if column.startswith('Unnamed'):
                 raw_block.drop(column, axis=1, inplace=True)
         raw_block = raw_block[:max_row]
         raw_block = raw_block.dropna(axis=1, how='all')
-        
+
         self.meta_df = raw_meta
-        self.block_df = raw_block        
-    
+        self.block_df = raw_block
+
     def read_csvs(self):
         """Read csv files
         """
-        #detect which csv is a block and which is meta based on 
-        #default name Google Drive assigns when downloading it
+        # detect which csv is a block and which is meta based on
+        # default name Google Drive assigns when downloading it
         if self.file[0].endswith('BlockData.csv'):
             block_file = self.file[0]
             meta_file = self.file[1]
         else:
             block_file = self.file[1]
             meta_file = self.file[0]
-            
+
         meta_path_file = os.path.join(self.path, meta_file)
         block_path_file = os.path.join(self.path, block_file)
-        raw_meta = pd.read_csv(meta_path_file, 
+        raw_meta = pd.read_csv(meta_path_file,
                                delimiter=',',
-                               skiprows=1, 
+                               skiprows=1,
                                names=['a', 'values', 'b', 'c'],
                                index_col=1,
                                dtype=str)
-        
-        
+
         raw_block = pd.read_csv(block_path_file,
-                                     delimiter=',',
-                                     header=2,
-                                     dtype=str)   
+                                delimiter=',', header=2, dtype=str)
         self._raw_meta = raw_meta
         self._raw_block = raw_block
-    
+
     def read_ods(self):
         """Read ods
         """
         path_file = os.path.join(self.path, self.file[0])
-        raw_meta = pd.read_excel(path_file, sheet_name='MetaData',index_col=1,
-                               names=['a', 'b', 'values', 'c', 'd'],
-                               dtype=str, 
-                               engine='odf')
-        raw_block = pd.read_excel(path_file, sheet_name='BlockData', 
-                                     header=2,
-                                     dtype=str,
-                                     engine='odf')
+        raw_meta = pd.read_excel(path_file, sheet_name='MetaData', index_col=1,
+                                 names=['a', 'b', 'values', 'c', 'd'],
+                                 dtype=str,
+                                 engine='odf')
+        raw_block = pd.read_excel(path_file, sheet_name='BlockData',
+                                  header=2,
+                                  dtype=str,
+                                  engine='odf')
         self._raw_meta = raw_meta
         self._raw_block = raw_block
-    
+
     def read_xlsx(self):
         """Read xlsx
         """
         raise NotImplementedError('TODO')
-    
+
     def read_gs(self):
         """Read Google Sheet
 
@@ -169,18 +167,17 @@ class ExpNoteReader():
             ToDo
         """
         raise NotImplementedError('TODO')
-    
+
     def merge_meta_block(self):
         """Merge meta and block dataframes and return as dictionary
         """
-        sub_block = self.block_df[self.block_df['block_id'].astype(int)==self.block_id].transpose().to_dict()
+        sub_block = self.block_df[self.block_df['block_id'].astype(int) == self.block_id].transpose().to_dict()
         key = list(sub_block.keys())[0]
         sub_block = sub_block[key]
         meta = self.meta_df.to_dict()
         meta.update(sub_block)
         self.nsds_meta = meta
- 
-    
+
     def dump_yaml(self, write_path=None):
         """Dump yaml file
 
@@ -195,7 +192,7 @@ class ExpNoteReader():
         nsds_meta = self.get_nsds_meta()
         write_path_file = os.path.join(write_path, self.block_folder + '.yaml')
         write_yaml(write_path_file, nsds_meta, sort_keys=True)
-    
+
     def get_nsds_meta(self):
         """Get parsed data
 

--- a/nsds_lab_to_nwb/metadata/keymap_helper.py
+++ b/nsds_lab_to_nwb/metadata/keymap_helper.py
@@ -1,5 +1,5 @@
-from nsds_lab_to_nwb.common.io import read_yaml
 from nsds_lab_to_nwb.metadata.resources import read_metadata_resource
+
 
 def _remap_and_inject(metadata_parsed, old_key, value, mapto=None):
     if mapto is None:
@@ -21,6 +21,7 @@ def _remap_and_inject(metadata_parsed, old_key, value, mapto=None):
         if new_key not in target:
             target[new_key] = {}
         target = target[new_key]
+
 
 def apply_keymap(metadata_input, keymap_file='metadata_keymap', key_for_unknown='other'):
     keymap = read_metadata_resource(keymap_file)
@@ -46,8 +47,7 @@ if __name__ == '__main__':
         'poly_type': 'cambXX',
         'ecog': 'TRUE',
         'poly': 'FALSE',
-        'notes': 'This is a test.'
-        }
+        'notes': 'This is a test.'}
     metadata_parsed = apply_keymap(metadata_input=TEST_METADATA,
                                    keymap_file='metadata_keymap')
     print(metadata_parsed)

--- a/nsds_lab_to_nwb/metadata/metadata_manager.py
+++ b/nsds_lab_to_nwb/metadata/metadata_manager.py
@@ -1,12 +1,10 @@
 import logging
 import os
-import csv
 import numpy as np
-import pandas as pd
 from nsds_lab_to_nwb.utils import (get_metadata_lib_path, get_stim_lib_path,
                                    split_block_folder)
 
-from nsds_lab_to_nwb.common.io import read_yaml, write_yaml, csv_to_dict
+from nsds_lab_to_nwb.common.io import read_yaml, write_yaml
 from nsds_lab_to_nwb.metadata.exp_note_reader import ExpNoteReader
 from nsds_lab_to_nwb.metadata.keymap_helper import apply_keymap
 from nsds_lab_to_nwb.metadata.resources import read_metadata_resource
@@ -22,11 +20,11 @@ class MetadataReader:
     ''' Reads metadata input for new experiments.
     '''
     def __init__(self,
-                block_metadata_path: str,
-                metadata_lib_path: str,
-                block_folder: str,
-                metadata_save_path=None,
-                ):
+                 block_metadata_path: str,
+                 metadata_lib_path: str,
+                 block_folder: str,
+                 metadata_save_path=None,
+                 ):
         self.block_metadata_path = block_metadata_path
         self.metadata_lib_path = get_metadata_lib_path(metadata_lib_path)
         self.block_folder = block_folder
@@ -106,8 +104,7 @@ class MetadataReader:
             if 'filtering' not in device_metadata[key]:
                 device_metadata[key]['filtering'] = (
                     'The signal is low pass filtered at 45 percent of the sample rate, '
-                    'and high pass filtered at 2 Hz.'
-                    )
+                    'and high pass filtered at 2 Hz.')
 
     def extra_cleanup(self):
         device_metadata = self.metadata_input['device']
@@ -129,8 +126,7 @@ class MetadataReader:
             if (ecog_lat_loc is not None) and (ecog_post_loc is not None):
                 device_metadata['ECoG']['location_details'] = (
                     f'{ecog_lat_loc} mm from lateral ridge '
-                    f'and {ecog_post_loc} mm from posterior ridge.'
-                    )
+                    f'and {ecog_post_loc} mm from posterior ridge.')
         if has_poly:
             device_metadata['Poly']['location_details'] = 'Within the ECoG grid.'
 
@@ -165,11 +161,11 @@ class LegacyMetadataReader(MetadataReader):
     ''' Reads metadata input for old experiments.
     '''
     def __init__(self,
-                block_metadata_path: str,
-                metadata_lib_path: str,
-                block_folder: str,
-                metadata_save_path=None,
-                ):
+                 block_metadata_path: str,
+                 metadata_lib_path: str,
+                 block_folder: str,
+                 metadata_save_path=None,
+                 ):
         super().__init__(block_metadata_path, metadata_lib_path,
                          block_folder, metadata_save_path)
 
@@ -200,8 +196,7 @@ class LegacyMetadataReader(MetadataReader):
         # fill in old subject information
         old_subject_input = read_metadata_resource('old_subject_metadata')
         old_subject_metadata = old_subject_input['subject_metadata']
-        old_subject_metadata['weight'] = old_subject_input['weights'].get(
-                                                    self.animal_name, 'Unknown')
+        old_subject_metadata['weight'] = old_subject_input['weights'].get(self.animal_name, 'Unknown')
         for key in old_subject_metadata:
             if key not in self.metadata_input['subject']:
                 self.metadata_input['subject'][key] = old_subject_metadata[key]
@@ -216,7 +211,7 @@ class LegacyMetadataReader(MetadataReader):
         if self.experiment_type == 'auditory':
             self.metadata_input['experiment_description'] = 'Auditory experiment'
         if ('session_description' not in self.metadata_input
-                    or len(self.metadata_input['session_description']) == 0):
+                or len(self.metadata_input['session_description']) == 0):
             self.metadata_input['session_description'] = (
                 'Auditory experiment with {} stimulus'.format(self.metadata_input['stimulus']['name']))
 
@@ -268,16 +263,16 @@ class MetadataManager:
 
         if self.legacy_block:
             self.metadata_reader = LegacyMetadataReader(
-                            block_metadata_path=self.block_metadata_path,
-                            metadata_lib_path=self.metadata_lib_path,
-                            block_folder=self.block_folder,
-                            metadata_save_path=self.metadata_save_path)
+                block_metadata_path=self.block_metadata_path,
+                metadata_lib_path=self.metadata_lib_path,
+                block_folder=self.block_folder,
+                metadata_save_path=self.metadata_save_path)
         else:
             self.metadata_reader = MetadataReader(
-                            block_metadata_path=self.block_metadata_path,
-                            metadata_lib_path=self.metadata_lib_path,
-                            block_folder=self.block_folder,
-                            metadata_save_path=self.metadata_save_path)
+                block_metadata_path=self.block_metadata_path,
+                metadata_lib_path=self.metadata_lib_path,
+                block_folder=self.block_folder,
+                metadata_save_path=self.metadata_save_path)
 
     def __detect_legacy_block(self, legacy_block=None):
         if (legacy_block is not None):
@@ -377,8 +372,8 @@ class MetadataManager:
                     device_metadata[key]['manufacturer'])
                 device_metadata[key]['description'] = (
                     f'{nchannels}-ch {key} '
-                    # f'({device_type}) '
-                    f'from {manufacturer}')
+                    f'from {manufacturer} '
+                    f'({device_type})')
 
                 # add device location if not already specified
                 if ('location' not in device_metadata[key] or

--- a/nsds_lab_to_nwb/metadata/resources/__init__.py
+++ b/nsds_lab_to_nwb/metadata/resources/__init__.py
@@ -3,6 +3,7 @@ import os
 
 from nsds_lab_to_nwb.common.io import read_yaml
 
+
 def read_metadata_resource(yaml_file):
     filename, ext = os.path.splitext(yaml_file)
     if ext not in ('.yaml', '.yml', ''):

--- a/nsds_lab_to_nwb/metadata/stim_name_helper.py
+++ b/nsds_lab_to_nwb/metadata/stim_name_helper.py
@@ -1,5 +1,5 @@
-from nsds_lab_to_nwb.common.io import read_yaml
 from nsds_lab_to_nwb.metadata.resources import read_metadata_resource
+
 
 def check_stimulus_name(stim_name_input):
     stim_directory = read_metadata_resource('list_of_stimuli')


### PR DESCRIPTION
# Description and related issues

cleaning up the `metadata` subpackage to remove flake8 errors.

# Checklist:

- [ ] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory
    - [x] only tested `test_metadata_manager.py`, which passes
- [x] (N/A) If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [x] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [ ] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory
    - [x] no formatting error from `flake8 nsds_lab_to_nwb/metadata`
