### PR TITLE
process different stimuli types

### DIFF
--- a/nsds_lab_to_nwb/common/io.py
+++ b/nsds_lab_to_nwb/common/io.py
@@ -2,6 +2,8 @@ import io
 import json
 import yaml
 import csv
+import h5py
+import scipy.io
 from collections import OrderedDict
 
 
@@ -42,3 +44,16 @@ def csv_to_dict(csv_file):
     if ('key', 'value') in mydict.items():
         mydict.pop('key')
     return mydict
+
+
+# --- other file types ---
+
+def read_mat_file(file_path):
+    try:
+        f = h5py.File(file_path, 'r')
+    except OSError:
+        # if we get 'OSError: Unable to open file (File signature not found)'
+        # this mat file may be from an earlier MATLAB version
+        # and is not in HDF5 format.
+        f = scipy.io.loadmat(file_path)
+    return f

--- a/nsds_lab_to_nwb/components/stimulus/mark_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/mark_manager.py
@@ -8,7 +8,7 @@ class MarkManager():
     def __init__(self, dataset):
         self.dataset = dataset
 
-    def get_mark_track(self, name='recorded_mark'):
+    def get_mark_track(self, starting_time, name='recorded_mark'):
         # Read the mark track
         if hasattr(self.dataset, 'htk_mark_path'):
             mark_file = HTKFile(self.dataset.htk_mark_path)
@@ -22,7 +22,7 @@ class MarkManager():
         mark_time_series = TimeSeries(name=name,
                                       data=mark_track,
                                       unit='Volts',
-                                      starting_time=0.0,
+                                      starting_time=starting_time,
                                       rate=rate,
                                       description='The stimulus mark track.')
         return mark_time_series

--- a/nsds_lab_to_nwb/components/stimulus/mark_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/mark_tokenizer.py
@@ -8,6 +8,11 @@ class MarkTokenizer():
         self.block_name = block_name
         self.stim_configs = stim_configs
 
+        self.tokenizable = True
+        if self.stim_configs['type'] == 'continuous':
+            self.tokenizable = False
+            return
+
         stim_name = self.stim_configs['name']
         if 'tone' in stim_name:
             self.tokenizer = ToneTokenizer(self.block_name, self.stim_configs)
@@ -16,7 +21,9 @@ class MarkTokenizer():
         elif 'wn' in stim_name:
             self.tokenizer = WNTokenizer(self.block_name, self.stim_configs)
         else:
-            raise ValueError("Unknown stimulus type '{stim_name}' for mark tokenizer")
+            raise ValueError(f"Unknown stimulus type '{stim_name}' for mark tokenizer")
 
     def tokenize(self, nwb_content):
+        if not self.tokenizable:
+            return
         self.tokenizer.tokenize(nwb_content)

--- a/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
+++ b/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
@@ -1,7 +1,5 @@
-import re
 import os
 import numpy as np
-import csv
 
 from nsds_lab_to_nwb.common.io import read_mat_file
 from nsds_lab_to_nwb.metadata.stim_name_helper import check_stimulus_name
@@ -80,7 +78,7 @@ def tone_stimulus_values(mat_file_path):
     # this offset value comes from mars; what is this?
     # variable naming (amp_offset) was by JHB and could be wrong
     amp_offset = 8
-    stim_vals[0,:] = stim_vals[0,:] + amp_offset
+    stim_vals[0, :] = stim_vals[0, :] + amp_offset
 
     return stim_vals
 
@@ -113,14 +111,16 @@ def gen_tone_stim_vals():
     Note: this is only used for test_tone_stim.yaml (see metadata repo)
     '''
     frqs = np.array([500, 577, 666, 769, 887, 1024, 1182,
-        1364, 1575, 1818, 2098, 2421, 2795, 3226, 3723,
-        4297, 4960, 5725, 6608, 7627, 8803, 10160, 11727,
-        13535, 15622, 18031, 20812, 24021, 27725, 32000])
-    amps = np.arange(1,9)
-    frqset, ampset = np.meshgrid(frqs,amps)
+                     1364, 1575, 1818, 2098, 2421, 2795, 3226, 3723,
+                     4297, 4960, 5725, 6608, 7627, 8803, 10160, 11727,
+                     13535, 15622, 18031, 20812, 24021, 27725, 32000])
+    amps = np.arange(1, 9)
+    frqset, ampset = np.meshgrid(frqs, amps)
     frq_amp_pairs = np.array([ampset.flatten(), frqset.flatten()]).T
-    np.random.seed(seed=1234) #Insure that the same order is produced with each call.
+    np.random.seed(seed=1234) # ensure that the same order is produced with each call.
     shuffle_inds1 = np.random.permutation(np.arange(frq_amp_pairs.shape[0]))
     shuffle_inds2 = np.random.permutation(np.arange(frq_amp_pairs.shape[0]))
-    stim_vals = np.concatenate((frq_amp_pairs[shuffle_inds1,:],frq_amp_pairs[shuffle_inds2,:]),axis=0)
+    stim_vals = np.concatenate((frq_amp_pairs[shuffle_inds1, :],
+                                frq_amp_pairs[shuffle_inds2, :]),
+                               axis=0)
     return stim_vals.T

--- a/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
+++ b/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
@@ -15,7 +15,14 @@ class StimValueExtractor():
 
     def extract(self):
         if self.stim_values_command is None:
-            return None
+            if self.stim_name in ('tone', 'tone150'):
+                stim_values_path = self._get_stim_values_path()
+                stim_values = tone_stimulus_values(stim_values_path)
+                return stim_values
+            else:
+                # TODO: catch other stimulus types as well
+                # return None
+                raise ValueError('missing input for stim_values')
 
         stim_values_command = self.stim_values_command
         if 'tone_stimulus_values' in stim_values_command:
@@ -40,7 +47,7 @@ class StimValueExtractor():
 
         return stim_values
 
-    def _get_stim_values_path(self, path_from_metadata):
+    def _get_stim_values_path(self, path_from_metadata=None):
         # prioritize path from list_of_stimuli.yaml in this package
         _, stim_info = check_stimulus_name(self.stim_name)
         path_from_los = stim_info['stim_values_path']
@@ -57,7 +64,19 @@ class StimValueExtractor():
 
 
 def tone_stimulus_values(mat_file_path):
-    ''' adapted from mars.configs.block_directory '''
+    ''' adapted from mars.configs.block_directory
+
+    Parameters:
+    -----------
+    mat_file_path: full path to a .mat file that contains stim_values.
+
+    Returns:
+    --------
+    stim_vals: a 2D array with two rows along the leading dimension.
+        stim_vals[0, :] are the amplitudes,
+        stim_vals[1, :] are the frequencies of the tones.
+        (should confirm!)
+    '''
     sio = read_mat_file(mat_file_path)
     stim_vals = sio['stimVls'][:].astype(int)
 

--- a/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
+++ b/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
@@ -11,10 +11,13 @@ from nsds_lab_to_nwb.metadata.stim_name_helper import check_stimulus_name
 class StimValueExtractor():
     def __init__(self, stim_configs, stim_lib_path):
         self.stim_name = stim_configs['name']
-        self.stim_values_command = stim_configs['stim_values']
+        self.stim_values_command = stim_configs.get('stim_values', None)
         self.stim_lib_path = stim_lib_path
 
     def extract(self):
+        if self.stim_values_command is None:
+            return None
+
         stim_values_command = self.stim_values_command
         if 'tone_stimulus_values' in stim_values_command:
             extractor, filename = self.__parse_command(stim_values_command)

--- a/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
+++ b/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import csv
 import h5py
-# import pkg_resources
+import scipy.io
 
 from nsds_lab_to_nwb.metadata.stim_name_helper import check_stimulus_name
 
@@ -59,9 +59,16 @@ class StimValueExtractor():
 
 def tone_stimulus_values(mat_file_path):
     ''' adapted from mars.configs.block_directory '''
-    with h5py.File(mat_file_path, 'r') as sio:
+    try:
+        with h5py.File(mat_file_path, 'r') as sio:
+            stim_vals = sio['stimVls'][:].astype(int)
+    except OSError:
+        # if we get 'OSError: Unable to open file (File signature not found)'
+        # this mat file may be from an earlier MATLAB version
+        # and is not in HDF5 format.
+        sio = scipy.io.loadmat(mat_file_path)
         stim_vals = sio['stimVls'][:].astype(int)
-    stim_vals[0,:] = stim_vals[0,:]+8
+    stim_vals[0,:] = stim_vals[0,:] + 8
     return stim_vals
 
 

--- a/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
+++ b/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
@@ -7,28 +7,40 @@ class StimulusOriginator():
     def __init__(self, dataset, metadata):
         self.dataset = dataset
         self.metadata = metadata
+        self.stim_configs = self.metadata['stimulus']
 
         self.mark_manager = MarkManager(self.dataset)
         self.mark_tokenizer = MarkTokenizer(self.metadata['block_name'],
-                                            self.metadata['stimulus'])
+                                            self.stim_configs)
 
         self.wav_manager = WavManager(self.dataset.stim_lib_path,
-                                      self.metadata['stimulus'])
+                                      self.stim_configs)
 
     def make(self, nwb_content):
         # add mark track
-        mark_time_series = self.mark_manager.get_mark_track()
+        mark_starting_time = 0.0    # <<<< legacy behavior. confirm! always at 0.0?
+        mark_time_series = self.mark_manager.get_mark_track(starting_time=mark_starting_time)
         nwb_content.add_stimulus(mark_time_series)
 
         # tokenize into trials, once mark track has been added to nwb_content
         self.mark_tokenizer.tokenize(nwb_content)
 
         # add stimulus WAV data
-        first_recorded_mark = self.__get_first_recorded_mark(nwb_content)
-        stim_wav_time_series = self.wav_manager.get_stim_wav(first_recorded_mark)
+        stim_starting_time = self._get_stim_starting_time(nwb_content)
+        stim_wav_time_series = self.wav_manager.get_stim_wav(starting_time=stim_starting_time)
         nwb_content.add_stimulus(stim_wav_time_series)
 
-    def __get_first_recorded_mark(self, nwb_content):
-        time_table = nwb_content.trials.to_dataframe().query('sb == "s"')['start_time']
-        # return time_table[1]  # <<< this was MARS version; legacy from matlab code?
-        return time_table.values[0]
+    def _get_stim_starting_time(self, nwb_content):
+        if self.mark_tokenizer.tokenizable:
+            time_table = nwb_content.trials.to_dataframe().query('sb == "s"')['start_time']
+            # first_recorded_mark = time_table[1]  # <<< this was MARS version; legacy from matlab code?
+            first_recorded_mark = time_table.values[0]
+        else:
+            # continuous stimulus
+            first_recorded_mark = 0.0    # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< just a guess. confirm!!!
+
+        # starting time for the stimulus TimeSeries
+        stim_starting_time = (first_recorded_mark
+                         - self.stim_configs['mark_offset']  # adjust for mark offset
+                         - self.stim_configs['first_mark'])  # time between stimulus DVD start and the first mark
+        return stim_starting_time

--- a/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
+++ b/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
@@ -41,6 +41,6 @@ class StimulusOriginator():
 
         # starting time for the stimulus TimeSeries
         stim_starting_time = (first_recorded_mark
-                         - self.stim_configs['mark_offset']  # adjust for mark offset
-                         - self.stim_configs['first_mark'])  # time between stimulus DVD start and the first mark
+                              - self.stim_configs['mark_offset']  # adjust for mark offset
+                              - self.stim_configs['first_mark'])  # time between stimulus DVD start and the first mark
         return stim_starting_time

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/timit_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/timit_tokenizer.py
@@ -6,7 +6,7 @@ from nsds_lab_to_nwb.components.stimulus.tokenizers.stimulus_tokenizer import St
 class TIMITTokenizer(StimulusTokenizer):
     """
     Tokenize TIMIT stimulus data
-    
+
     Original version author: Max Dougherty <maxdougherty@lbl.gov>
     As part of MARS
     """
@@ -34,7 +34,7 @@ class TIMITTokenizer(StimulusTokenizer):
 
         # TODO: Assert that the # of stim vals is equal to the number of found onsets
         assert len(stim_onsets)==len(stim_vals), (
-                    "Incorrect number of stimulus onsets found." 
+                    "Incorrect number of stimulus onsets found."
                     + " Expected {:d}, found {:d}.".format(stim_vals.shape[1],len(stim_onsets))
                     + " Perhaps you are not using the correct tokenizer?"
                     )
@@ -48,9 +48,9 @@ class TIMITTokenizer(StimulusTokenizer):
         nwb_content.add_trial(start_time=stim_onsets[-1]+bl_end, stop_time=rec_end_time, sb='b', sample_filename=stim_vals[-1])
 
     def __already_tokenized(self, nwb_content):
-        return (nwb_content.trials and 
-                'sb' in nwb_content.trials.colnames and 
-                'frq' in nwb_content.trials.colnames and 
+        return (nwb_content.trials and
+                'sb' in nwb_content.trials.colnames and
+                'frq' in nwb_content.trials.colnames and
                 'amp' in nwb_content.trials.colnames)
 
     def __get_stim_onsets(self, nwb_content, mark_name):

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/tone_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/tone_tokenizer.py
@@ -6,7 +6,7 @@ from nsds_lab_to_nwb.components.stimulus.tokenizers.stimulus_tokenizer import St
 class ToneTokenizer(StimulusTokenizer):
     """
     Tokenize tone pip stimulus data
-    
+
     Original version author: Max Dougherty <maxdougherty@lbl.gov>
     As part of MARS
     """
@@ -16,7 +16,7 @@ class ToneTokenizer(StimulusTokenizer):
     def tokenize(self, nwb_content, mark_name='recorded_mark'):
         """
         """
-        
+
         if self.__already_tokenized(nwb_content):
             print('Block has already been tokenized')
             return
@@ -33,14 +33,14 @@ class ToneTokenizer(StimulusTokenizer):
 
         # Add the pre-stimulus period to baseline
         nwb_content.add_trial(start_time=0.0,
-                                stop_time=stim_onsets[0]-stim_dur, 
+                                stop_time=stim_onsets[0]-stim_dur,
                                 sb='b',
                                 frq=str(float(stim_vals[1,0])),
                                 amp=str(float(stim_vals[0,0])))
 
         # TODO: Assert that the # of stim vals is equal to the number of found onsets
         assert len(stim_onsets)==stim_vals.shape[1], (
-                    "Incorrect number of stimulus onsets found." 
+                    "Incorrect number of stimulus onsets found."
                     + " Expected {:d}, found {:d}.".format(stim_vals.shape[1],len(stim_onsets))
                     + " Perhaps you are not using the correct tokenizer?"
                     )
@@ -60,9 +60,9 @@ class ToneTokenizer(StimulusTokenizer):
                                 sb='b', frq=frq, amp=amp)
 
     def __already_tokenized(self, nwb_content):
-        return (nwb_content.trials and 
-                'sb' in nwb_content.trials.colnames and 
-                'frq' in nwb_content.trials.colnames and 
+        return (nwb_content.trials and
+                'sb' in nwb_content.trials.colnames and
+                'frq' in nwb_content.trials.colnames and
                 'amp' in nwb_content.trials.colnames)
 
     def __get_stim_onsets(self, nwb_content, mark_name):

--- a/nsds_lab_to_nwb/components/stimulus/wav_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/wav_manager.py
@@ -13,7 +13,7 @@ class WavManager():
         self.stim_name = stim_configs['name']
         self.stim_lib_path = get_stim_lib_path(stim_lib_path)
         self.stim_configs = stim_configs
-        self.__load_stim_values()
+        self._load_stim_values()
 
     def get_stim_wav(self, first_mark, name='recorded_mark'):
         if self.stim_name == 'wn1':
@@ -46,12 +46,9 @@ class WavManager():
         _, stim_info = check_stimulus_name(stim_name)
         return os.path.join(stim_path, stim_info['audio_path'])
 
-    def __load_stim_values(self):
+    def _load_stim_values(self):
         '''load stim_values from .mat or .csv files,
         or generate using original script (mars/configs/block_directory.py)
         '''
-        if not ('stim_values' in self.stim_configs):
-            self.stim_configs['stim_values'] = None
-        else:
-            sve = StimValueExtractor(self.stim_configs, self.stim_lib_path)
-            self.stim_configs['stim_values'] = sve.extract()
+        sve = StimValueExtractor(self.stim_configs, self.stim_lib_path)
+        self.stim_configs['stim_values'] = sve.extract()

--- a/nsds_lab_to_nwb/components/stimulus/wav_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/wav_manager.py
@@ -46,21 +46,6 @@ class WavManager():
         _, stim_info = check_stimulus_name(stim_name)
         return os.path.join(stim_path, stim_info['audio_path'])
 
-    @staticmethod
-    def append_stim_folder(stim_name, path):
-        if stim_name == 'tone150':
-            return os.path.join(path, 'Tone150')
-        elif stim_name == 'timit':
-            return os.path.join(path, 'TIMIT')
-        elif stim_name == 'tone':
-            return os.path.join(path, 'Tone')
-        elif stim_name == 'wn2':
-            return os.path.join(path, 'WN')
-        elif stim_name == 'dmr':
-            return os.path.join(path, 'DMR')
-        else:
-            raise ValueError(f"Unknown stimulus type '{stim_name}'")
-
     def __load_stim_values(self):
         '''load stim_values from .mat or .csv files,
         or generate using original script (mars/configs/block_directory.py)
@@ -68,7 +53,5 @@ class WavManager():
         if not ('stim_values' in self.stim_configs):
             self.stim_configs['stim_values'] = None
         else:
-            sve = StimValueExtractor(self.stim_configs['stim_values'],
-                                     self.append_stim_folder(self.stim_name,
-                                                             self.stim_lib_path))
+            sve = StimValueExtractor(self.stim_configs, self.stim_lib_path)
             self.stim_configs['stim_values'] = sve.extract()

--- a/nsds_lab_to_nwb/components/stimulus/wav_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/wav_manager.py
@@ -29,11 +29,11 @@ class WavManager():
         # Create the stimulus timeseries
         rate = float(stim_wav_fs)
         stim_time_series = TimeSeries(name=name,
-                            data=stim_wav,
-                            starting_time=starting_time,
-                            unit='Volts',
-                            rate=rate,
-                            description='The neural recording aligned stimulus track.')
+                                      data=stim_wav,
+                                      starting_time=starting_time,
+                                      unit='Volts',
+                                      rate=rate,
+                                      description='The neural recording aligned stimulus track.')
         return stim_time_series
 
     @staticmethod

--- a/nsds_lab_to_nwb/components/stimulus/wav_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/wav_manager.py
@@ -15,19 +15,14 @@ class WavManager():
         self.stim_configs = stim_configs
         self._load_stim_values()
 
-    def get_stim_wav(self, first_mark, name='recorded_mark'):
+    def get_stim_wav(self, starting_time, name='raw_stimulus'):
         if self.stim_name == 'wn1':
             return None
         return self._get_stim_wav(self.get_stim_file(self.stim_name, self.stim_lib_path),
-                                  first_mark)
+                                  starting_time, name=name)
 
-    def _get_stim_wav(self, stim_file, first_recorded_mark, name='raw_stimulus'):
+    def _get_stim_wav(self, stim_file, starting_time, name='raw_stimulus'):
         ''' get the raw wav stimulus track '''
-        # find starting time
-        starting_time = (first_recorded_mark
-                            - self.stim_configs['mark_offset']  # adjust for mark offset
-                            - self.stim_configs['first_mark'])  # time between stimulus DVD start and the first mark
-
         # Read the stimulus wav file
         stim_wav_fs, stim_wav = wavfile.read(stim_file)
 

--- a/nsds_lab_to_nwb/metadata/metadata_manager.py
+++ b/nsds_lab_to_nwb/metadata/metadata_manager.py
@@ -352,6 +352,7 @@ class MetadataManager:
         if stim_name != stimulus_metadata['name']:
             stimulus_metadata['alt_name'] = stimulus_metadata['name']
         stim_yaml_path = os.path.join(self.yaml_lib_path, 'stimulus', stim_name + '.yaml')
+        logger.debug(f'Trying to read stimulus metadata from {stim_yaml_path}...')
         stimulus_metadata.update(read_yaml(stim_yaml_path))
 
     def __load_probes(self, device_metadata):

--- a/nsds_lab_to_nwb/metadata/metadata_manager.py
+++ b/nsds_lab_to_nwb/metadata/metadata_manager.py
@@ -81,6 +81,15 @@ class MetadataReader:
             if 'g' not in weight:
                 subject_metadata['weight'] = f'{weight}g'
 
+        null_stim_name = None  # distinguish from intended stimulus-less session ("baseline")
+        if 'stimulus' not in self.metadata_input:
+            self.metadata_input['stimulus'] = {'name': null_stim_name}
+        if 'name' not in self.metadata_input['stimulus']:
+            self.metadata_input['stimulus']['name'] = null_stim_name
+        stim_name = self.metadata_input['stimulus']['name']
+        if not isinstance(stim_name, str) or stim_name in ('nan', '.nan'):
+            self.metadata_input['stimulus']['name'] = null_stim_name
+
         if 'session_description' not in self.metadata_input:
             try:
                 self.metadata_input['session_description'] = self.metadata_input['stimulus']['name']
@@ -348,6 +357,12 @@ class MetadataManager:
                 metadata['subject'][key] = 'Unknown'
 
     def __load_stimulus_info(self, stimulus_metadata):
+        if stimulus_metadata['name'] is None:
+            # indicates that stimulus is not specified for this block
+            # NWBBuilder will decide what to do in this case
+            logger.info('Unspecified stimulus in metadata.')
+            return
+
         stim_name, _ = check_stimulus_name(stimulus_metadata['name'])
         if stim_name != stimulus_metadata['name']:
             stimulus_metadata['alt_name'] = stimulus_metadata['name']

--- a/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
@@ -60,11 +60,3 @@ baseline:
     audio_path: ''
     marker_path: ''
     parameter_path: ''
-
-# probably unnecessary
-nan:
-    alt_names: []
-    description: 'Stimulus is not specified. To be distinguised from a stimulus-free (baseline) block.'
-    audio_path: ''
-    marker_path: ''
-    parameter_path: ''

--- a/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
@@ -10,6 +10,12 @@
 #               indicating when events happens in auditory stimulus
 #   parameter_path: (str) path to the mat file, when available,
 #               that stores parameters that describe auditory stimlus
+#   stim_values_path: (str) path to the mat file, when available,
+#               that stores the stim_values (used in stim_value_extractor.py)
+#               ***************************************************************
+#               (Q: Is this redundant information?
+#                   Can we extract same data from audio_path or parameter_path?)
+#               ***************************************************************
 # ---------------------------------------------------------------
 
 tone150:
@@ -18,6 +24,7 @@ tone150:
     audio_path: 'Tone150/freq_resp_area_stimulus_signal_flo500Hz_fhi32000Hz_nfreq30_natten1_nreps150_fs96000.wav'
     marker_path: 'Tone150/freq_resp_area_stimulus_trigger_flo500Hz_fhi32000Hz_nfreq30_natten1_nreps150_fs96000.wav'
     parameter_path: 'Tone150/freq_resp_area_stimulus_signal_flo500Hz_fhi32000Hz_nfreq30_natten1_nreps150_fs96000.mat'
+    stim_values_path: 'Tone150/Tone150_stim_stimVls.mat'
 
 timit:
     alt_names: ['Timit998']
@@ -25,6 +32,7 @@ timit:
     audio_path: 'TIMIT/timit998/timit998s.wav'
     marker_path: 'TIMIT/timit998/timit998m.wav'
     parameter_path: 'TIMIT/timit998/timit998.mat'
+    stim_values_path: ''
 
 tone:
     alt_names: ['Full tone']
@@ -32,6 +40,7 @@ tone:
     audio_path: 'Tone/stimulus_signal_03202013.wav'
     marker_path: 'Tone/stimulus_trigger_03202013.wav'
     parameter_path: ''
+    stim_values_path: ''
 
 wn2:
     alt_names: ['White noise']
@@ -39,6 +48,7 @@ wn2:
     audio_path: 'WN/tb_noise_burst_stim_fs96kHz_signal.wav'
     marker_path: 'WN/tb_noise_burst_stim_fs96kHz_trigger.wav'
     parameter_path: ''
+    stim_values_path: ''
 
 dmr:
     alt_names: ['Ripple']
@@ -46,6 +56,7 @@ dmr:
     audio_path: 'DMR/dmr-500flo-40000fhi-4SM-40TM-40db-96khz-48DF-15min.wav'
     marker_path: 'DMR/trig-dmr-500flo-40000fhi-4SM-40TM-40db-96khz-48DF-15min.wav'
     parameter_path: ''
+    stim_values_path: ''
 
 tone_diagnostic:
     alt_names: ['Tone diagnostic']
@@ -53,6 +64,7 @@ tone_diagnostic:
     audio_path: ''
     marker_path: ''
     parameter_path: ''
+    stim_values_path: ''
 
 baseline:
     alt_names: ['Baseline']
@@ -60,6 +72,7 @@ baseline:
     audio_path: ''
     marker_path: ''
     parameter_path: ''
+    stim_values_path: ''
 
 nan:
     alt_names: []
@@ -67,3 +80,4 @@ nan:
     audio_path: ''
     marker_path: ''
     parameter_path: ''
+    stim_values_path: ''

--- a/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
@@ -10,12 +10,6 @@
 #               indicating when events happens in auditory stimulus
 #   parameter_path: (str) path to the mat file, when available,
 #               that stores parameters that describe auditory stimlus
-#   stim_values_path: (str) path to the mat file, when available,
-#               that stores the stim_values (used in stim_value_extractor.py)
-#               ***************************************************************
-#               (Q: Is this redundant information?
-#                   Can we extract same data from audio_path or parameter_path?)
-#               ***************************************************************
 # ---------------------------------------------------------------
 
 tone150:
@@ -23,24 +17,21 @@ tone150:
     description: ''
     audio_path: 'Tone150/freq_resp_area_stimulus_signal_flo500Hz_fhi32000Hz_nfreq30_natten1_nreps150_fs96000.wav'
     marker_path: 'Tone150/freq_resp_area_stimulus_trigger_flo500Hz_fhi32000Hz_nfreq30_natten1_nreps150_fs96000.wav'
-    parameter_path: 'Tone150/freq_resp_area_stimulus_signal_flo500Hz_fhi32000Hz_nfreq30_natten1_nreps150_fs96000.mat'
-    stim_values_path: 'Tone150/Tone150_stim_stimVls.mat'
+    parameter_path: 'Tone150/freq_resp_area_stimulus_params_flo500Hz_fhi32000Hz_nfreq30_natten1_nreps150_fs96000.mat'
 
 timit:
     alt_names: ['Timit998']
     description: ''
     audio_path: 'TIMIT/timit998/timit998s.wav'
     marker_path: 'TIMIT/timit998/timit998m.wav'
-    parameter_path: 'TIMIT/timit998/timit998.mat'
-    stim_values_path: ''
+    parameter_path: 'TIMIT/timit998/timit998.txt'
 
 tone:
     alt_names: ['Full tone']
     description: ''
     audio_path: 'Tone/stimulus_signal_03202013.wav'
     marker_path: 'Tone/stimulus_trigger_03202013.wav'
-    parameter_path: ''
-    stim_values_path: 'Tone/Tone.stimVls.mat'   # copied from mars.configs
+    parameter_path: 'Tone/Tone.stimVls.mat'   # copied from mars.configs
 
 wn2:
     alt_names: ['White noise']
@@ -48,7 +39,6 @@ wn2:
     audio_path: 'WN/tb_noise_burst_stim_fs96kHz_signal.wav'
     marker_path: 'WN/tb_noise_burst_stim_fs96kHz_trigger.wav'
     parameter_path: ''
-    stim_values_path: ''
 
 dmr:
     alt_names: ['Ripple']
@@ -56,7 +46,6 @@ dmr:
     audio_path: 'DMR/dmr-500flo-40000fhi-4SM-40TM-40db-96khz-48DF-15min.wav'
     marker_path: 'DMR/trig-dmr-500flo-40000fhi-4SM-40TM-40db-96khz-48DF-15min.wav'
     parameter_path: ''
-    stim_values_path: ''
 
 tone_diagnostic:
     alt_names: ['Tone diagnostic']
@@ -64,7 +53,6 @@ tone_diagnostic:
     audio_path: ''
     marker_path: ''
     parameter_path: ''
-    stim_values_path: ''
 
 baseline:
     alt_names: ['Baseline']
@@ -72,7 +60,6 @@ baseline:
     audio_path: ''
     marker_path: ''
     parameter_path: ''
-    stim_values_path: ''
 
 nan:
     alt_names: []
@@ -80,4 +67,3 @@ nan:
     audio_path: ''
     marker_path: ''
     parameter_path: ''
-    stim_values_path: ''

--- a/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
@@ -61,9 +61,10 @@ baseline:
     marker_path: ''
     parameter_path: ''
 
+# probably unnecessary
 nan:
     alt_names: []
-    description: ''
+    description: 'Stimulus is not specified. To be distinguised from a stimulus-free (baseline) block.'
     audio_path: ''
     marker_path: ''
     parameter_path: ''

--- a/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
@@ -40,7 +40,7 @@ tone:
     audio_path: 'Tone/stimulus_signal_03202013.wav'
     marker_path: 'Tone/stimulus_trigger_03202013.wav'
     parameter_path: ''
-    stim_values_path: ''
+    stim_values_path: 'Tone/Tone.stimVls.mat'   # copied from mars.configs
 
 wn2:
     alt_names: ['White noise']

--- a/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
@@ -60,3 +60,10 @@ baseline:
     audio_path: ''
     marker_path: ''
     parameter_path: ''
+
+nan:
+    alt_names: []
+    description: ''
+    audio_path: ''
+    marker_path: ''
+    parameter_path: ''

--- a/nsds_lab_to_nwb/nwb_builder.py
+++ b/nsds_lab_to_nwb/nwb_builder.py
@@ -52,6 +52,7 @@ class NWBBuilder:
             block_metadata_path: str,
             metadata_lib_path: str = None,
             stim_lib_path: str = None,
+            metadata_save_path: str = None,
             use_htk=False
     ):
         self.data_path = get_data_path(data_path)
@@ -61,13 +62,12 @@ class NWBBuilder:
         self.block_folder = block_folder
         self.save_path = save_path
         self.block_metadata_path = block_metadata_path
-        self.metadata_lib_path = metadata_lib_path
         self.stim_lib_path = stim_lib_path
+        self.metadata_save_path = metadata_save_path
         self.use_htk = use_htk
 
         logger.info('Collecting metadata for NWB conversion...')
-        self.metadata = self._collect_nwb_metadata(block_metadata_path,
-                                                   metadata_lib_path, stim_lib_path)
+        self.metadata = self._collect_nwb_metadata()
         self.experiment_type = self.metadata['experiment_type']
 
         logger.info('Collecting relevant input data paths...')
@@ -86,13 +86,14 @@ class NWBBuilder:
         logger.info('Extracting session start time...')
         self.session_start_time = self._extract_session_start_time()
 
-    def _collect_nwb_metadata(self, block_metadata_path, metadata_lib_path, stim_lib_path):
+    def _collect_nwb_metadata(self):
         # collect metadata for NWB conversion
         self.metadata_manager = MetadataManager(
             block_folder=self.block_folder,
-            block_metadata_path=block_metadata_path,
-            metadata_lib_path=metadata_lib_path,
-            stim_lib_path=stim_lib_path)
+            block_metadata_path=self.block_metadata_path,
+            metadata_lib_path=self.metadata_lib_path,
+            stim_lib_path=self.stim_lib_path,
+            metadata_save_path=self.metadata_save_path)
         return self.metadata_manager.extract_metadata()
 
     def _collect_dataset_paths(self):

--- a/nsds_lab_to_nwb/nwb_builder.py
+++ b/nsds_lab_to_nwb/nwb_builder.py
@@ -40,6 +40,11 @@ class NWBBuilder:
         Path to metadata library repo.
     stim_lib_path : str
         Path to stimulus library.
+    metadata_save_path : str
+        Path to (optionally) save metadata input as yaml files.
+    resample_data : bool
+        Resample neural data to the nearest kHz.
+        Passed to resample_flag kwarg in NeuralDataOriginator.
     use_htk : bool
         Use data from HTK files.
     """
@@ -53,6 +58,7 @@ class NWBBuilder:
             metadata_lib_path: str = None,
             stim_lib_path: str = None,
             metadata_save_path: str = None,
+            resample_data=True,
             use_htk=False
     ):
         self.data_path = get_data_path(data_path)
@@ -64,6 +70,7 @@ class NWBBuilder:
         self.block_metadata_path = block_metadata_path
         self.stim_lib_path = stim_lib_path
         self.metadata_save_path = metadata_save_path
+        self.resample_data = resample_data
         self.use_htk = use_htk
 
         logger.info('Collecting metadata for NWB conversion...')
@@ -80,7 +87,8 @@ class NWBBuilder:
 
         logger.info('Creating originator instances...')
         self.electrodes_originator = ElectrodesOriginator(self.metadata)
-        self.neural_data_originator = NeuralDataOriginator(self.dataset, self.metadata)
+        self.neural_data_originator = NeuralDataOriginator(self.dataset, self.metadata,
+                                                           resample_flag=self.resample_data)
         self.stimulus_originator = StimulusOriginator(self.dataset, self.metadata)
 
         logger.info('Extracting session start time...')

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -16,18 +16,18 @@ class TestCase_Build_NWB(unittest.TestCase):
     # --------------------------------------------------------------
     # currently failing blocks:
     # new test blocks: RVG16_{B02, B04, B05, B06, B07, B08, B09, B10}
-    #     - B02, B04, B05: tone diagnostic (no metadata yaml)
+    #     - B02, B04, B05: tone_diagnostic (no associated files in list_of_stimuli.yaml)
     #     - B06: Tone                                <<<<<<< now passes with resample_data=False
     #     - B07: Tone150                             <<<<<<< now passes with resample_data=False
-    #     - B08: TIMIT: FileNotFoundError TIMIT/timit998.txt
-    #     - B09: stimulus type 'nan' not found
+    #     - B08: TIMIT                               <<<<<<< now passes with resample_data=False
+    #     - B09: stimulus 'nan'                      <<<<<<< now passes (stops gracefully)
     #     - B10: ValueError: Unknown stimulus type '{stim_name}' for mark tokenizer
     # legacy test block: R56_B10: metadata yaml not found in data_path
     # --------------------------------------------------------------
 
     def test_build_nwb_single_block(self):
         ''' build NWB but do not write file to disk '''
-        block_folder = 'RVG16_B06'
+        block_folder = 'RVG16_B09'
         resample_data = False   # for testing
         use_htk = False
         self.__build_nwb_content(block_folder, resample_data, use_htk)

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -17,9 +17,9 @@ class TestCase_Build_NWB(unittest.TestCase):
     # currently failing blocks:
     # new test blocks: RVG16_{B02, B04, B05, B06, B07, B08, B09, B10}
     #     - B02, B04, B05: tone diagnostic (no metadata yaml)
-    #     - B06: unable to open file Tone/Tone.stimVls.mat
-    #     - B07: unable to open file Tone150/Tone150.stimVls.mat <<<<<<< now passes with resample_data=False
-    #     - B08: FileNotFoundError TIMIT/timit998.txt
+    #     - B06: Tone                                <<<<<<< now passes with resample_data=False
+    #     - B07: Tone150                             <<<<<<< now passes with resample_data=False
+    #     - B08: TIMIT: FileNotFoundError TIMIT/timit998.txt
     #     - B09: stimulus type 'nan' not found
     #     - B10: ValueError: Unknown stimulus type '{stim_name}' for mark tokenizer
     # legacy test block: R56_B10: metadata yaml not found in data_path
@@ -27,7 +27,7 @@ class TestCase_Build_NWB(unittest.TestCase):
 
     def test_build_nwb_single_block(self):
         ''' build NWB but do not write file to disk '''
-        block_folder = 'RVG16_B07'
+        block_folder = 'RVG16_B06'
         resample_data = False   # for testing
         use_htk = False
         self.__build_nwb_content(block_folder, resample_data, use_htk)

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -1,96 +1,42 @@
 import os
-import numpy as np
 import unittest
-import sys
-from pynwb import NWBHDF5IO
-sys.path.insert(0, '.')
 
 from nsds_lab_to_nwb.nwb_builder import NWBBuilder
 from nsds_lab_to_nwb.metadata.metadata_manager import MetadataManager
-
-PWD = os.path.dirname(os.path.abspath(__file__))
-USER_HOME = os.path.expanduser("~")
+from nsds_lab_to_nwb.utils import (split_block_folder, get_data_path,
+                                   get_metadata_lib_path, get_stim_lib_path)
 
 
 class TestCase_Build_NWB(unittest.TestCase):
 
-    # raw data path
-    data_path = '/clusterfs/NSDS_data/hackathon20201201/'
+    data_path = get_data_path()
+    metadata_save_path = '_test/'
+    out_path = '_test/'
 
-    # new base?
-    # data_path_tdt = '/clusterfs/NSDS_data/hackathon20201201/TTankBackup/'
-
-    # output path (this will not be used)
-    out_path = os.path.join(USER_HOME, 'Data/nwb_test/')
-    
-    def test_build_nwb_case1_old_data(self):
+    def test_build_nwb_single_block(self):
         ''' build NWB but do not write file to disk '''
-        animal_name = 'R56'
-        block = 'B13'
-        # link to metadata files
-        block_metadata_path = os.path.join(PWD, f'../yaml/{animal_name}/{animal_name}_{block}.yaml')
-        library_path = os.path.join(USER_HOME, 'Src/NSDSLab-NWB-metadata/')
-        # collect metadata needed to build the NWB file
-        nwb_metadata = MetadataManager(block_metadata_path=block_metadata_path,
-                                       library_path=library_path)
-        # create a builder for the block
-        nwb_builder = NWBBuilder(
-                        animal_name=animal_name,
-                        block=block,
-                        data_path=self.data_path,
-                        out_path=self.out_path,
-                        nwb_metadata=nwb_metadata
-                        )
-        # build the NWB file content
+        # --------------------------------------------------------------
+        # currently failing blocks:
+        # new test blocks:   RVG16_{B02, B04, B05, B06, B07, B08, B09, B10}
+        # legacy test block: R56_B10
+        block_folder = 'RVG16_B02'
+        use_htk = False
+        # --------------------------------------------------------------
+        self.__build_nwb_content(block_folder, use_htk)
+
+    def __build_nwb_content(self, block_folder, use_htk):
+        ''' build NWB but do not write file to disk '''
+        _, animal_name, _ = split_block_folder(block_folder)
+        block_metadata_path = os.path.join(self.data_path, animal_name, block_folder,
+                                           f"{block_folder}.yaml")
+        nwb_builder = NWBBuilder(data_path=self.data_path,
+                                 block_folder=block_folder,
+                                 save_path=self.out_path,
+                                 block_metadata_path=block_metadata_path,
+                                 metadata_save_path=self.metadata_save_path,
+                                 use_htk=use_htk)
         nwb_content = nwb_builder.build()
 
-    def test_build_nwb_case2_new_data_no_stim(self):
-        ''' build NWB but do not write file to disk '''
-        animal_name = 'RVG02'
-        block = 'B09'
-        block_name = '{}_{}'.format(animal_name, block)
-        # link to metadata files
-        block_metadata_path = os.path.join(PWD, f'_data/RVG02/block_data.csv')
-        library_path = os.path.join(USER_HOME, 'Src/NSDSLab-NWB-metadata/')
-        # collect metadata needed to build the NWB file
-        nwb_metadata = MetadataManager(block_name=block_name,
-                                       block_metadata_path=block_metadata_path,
-                                       library_path=library_path)
-        # create a builder for the block
-        nwb_builder = NWBBuilder(
-                        animal_name=animal_name,
-                        block=block,
-                        data_path=self.data_path,
-                        out_path=self.out_path,
-                        nwb_metadata=nwb_metadata
-                        )
-        # build the NWB file content
-        nwb_content = nwb_builder.build(process_stim=False)
-        
-
-    def test_build_nwb_case3_htk(self):
-        ''' build NWB but do not write file to disk '''
-        animal_name = 'R56'
-        block = 'B13'
-        block_name = '{}_{}'.format(animal_name, block)
-        block_metadata_path = os.path.join(PWD, f'../yaml/{animal_name}/{animal_name}_{block}.yaml')
-        library_path = os.path.join(USER_HOME, 'software/NSDSLab-NWB-metadata/')
-
-        # collect metadata needed to build the NWB file
-        nwb_metadata = MetadataManager(block_name=block_name,
-                                       block_metadata_path=block_metadata_path,
-                                       library_path=library_path)
-        # create a builder for the block
-        nwb_builder = NWBBuilder(
-                        animal_name=animal_name,
-                        block=block,
-                        data_path=self.data_path,
-                        out_path=self.out_path,
-                        nwb_metadata=nwb_metadata,
-                        use_htk=True
-                        )
-        # build the NWB file content
-        nwb_content = nwb_builder.build(process_stim=True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -20,14 +20,14 @@ class TestCase_Build_NWB(unittest.TestCase):
     #     - B06: Tone                                <<<<<<< now passes with resample_data=False
     #     - B07: Tone150                             <<<<<<< now passes with resample_data=False
     #     - B08: TIMIT                               <<<<<<< now passes with resample_data=False
-    #     - B09: stimulus 'nan'                      <<<<<<< now passes (stops gracefully)
-    #     - B10: ValueError: Unknown stimulus type '{stim_name}' for mark tokenizer
+    #     - B09: stimulus 'nan'                      <<<<<<< now passes (handled by Stopping gracefully)
+    #     - B10: dmr                                 <<<<<<< now passes (handled by not tokenizing)
     # legacy test block: R56_B10: metadata yaml not found in data_path
     # --------------------------------------------------------------
 
     def test_build_nwb_single_block(self):
         ''' build NWB but do not write file to disk '''
-        block_folder = 'RVG16_B09'
+        block_folder = 'RVG16_B10'
         resample_data = False   # for testing
         use_htk = False
         self.__build_nwb_content(block_folder, resample_data, use_htk)

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -13,22 +13,23 @@ class TestCase_Build_NWB(unittest.TestCase):
     metadata_save_path = '_test/'
     out_path = '_test/'
 
+    # --------------------------------------------------------------
+    # currently failing blocks:
+    # new test blocks: RVG16_{B02, B04, B05, B06, B07, B08, B09, B10}
+    #     - B02, B04, B05: tone diagnostic (no metadata yaml)
+    #     - B06: unable to open file Tone/Tone.stimVls.mat
+    #     - B07: unable to open file Tone150/Tone150.stimVls.mat <<<<<<< now passes with resample_data=False
+    #     - B08: FileNotFoundError TIMIT/timit998.txt
+    #     - B09: stimulus type 'nan' not found
+    #     - B10: ValueError: Unknown stimulus type '{stim_name}' for mark tokenizer
+    # legacy test block: R56_B10: metadata yaml not found in data_path
+    # --------------------------------------------------------------
+
     def test_build_nwb_single_block(self):
         ''' build NWB but do not write file to disk '''
-        # --------------------------------------------------------------
-        # currently failing blocks:
-        # new test blocks: RVG16_{B02, B04, B05, B06, B07, B08, B09, B10}
-        #                       B02, B04, B05: tone diagnostic (no metadata yaml)
-        #                       B06: unable to open file Tone/Tone.stimVls.mat
-        #                       B07: unable to open file Tone150/Tone150.stimVls.mat
-        #                       B08: FileNotFoundError TIMIT/timit998.txt
-        #                       B09: stimulus type 'nan' not found
-        #                       B10: ValueError: Unknown stimulus type '{stim_name}' for mark tokenizer
-        # legacy test block: R56_B10: metadata yaml not found in data_path
         block_folder = 'RVG16_B07'
         resample_data = False   # for testing
         use_htk = False
-        # --------------------------------------------------------------
         self.__build_nwb_content(block_folder, resample_data, use_htk)
 
     def __build_nwb_content(self, block_folder, resample_data=True, use_htk=False):

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -25,12 +25,13 @@ class TestCase_Build_NWB(unittest.TestCase):
         #                       B09: stimulus type 'nan' not found
         #                       B10: ValueError: Unknown stimulus type '{stim_name}' for mark tokenizer
         # legacy test block: R56_B10: metadata yaml not found in data_path
-        block_folder = 'R56_B10'
+        block_folder = 'RVG16_B07'
+        resample_data = False   # for testing
         use_htk = False
         # --------------------------------------------------------------
-        self.__build_nwb_content(block_folder, use_htk)
+        self.__build_nwb_content(block_folder, resample_data, use_htk)
 
-    def __build_nwb_content(self, block_folder, use_htk):
+    def __build_nwb_content(self, block_folder, resample_data=True, use_htk=False):
         ''' build NWB but do not write file to disk '''
         _, animal_name, _ = split_block_folder(block_folder)
         block_metadata_path = os.path.join(self.data_path, animal_name, block_folder,
@@ -40,6 +41,7 @@ class TestCase_Build_NWB(unittest.TestCase):
                                  save_path=self.out_path,
                                  block_metadata_path=block_metadata_path,
                                  metadata_save_path=self.metadata_save_path,
+                                 resample_data=resample_data,
                                  use_htk=use_htk)
         nwb_content = nwb_builder.build()
 

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -17,9 +17,15 @@ class TestCase_Build_NWB(unittest.TestCase):
         ''' build NWB but do not write file to disk '''
         # --------------------------------------------------------------
         # currently failing blocks:
-        # new test blocks:   RVG16_{B02, B04, B05, B06, B07, B08, B09, B10}
-        # legacy test block: R56_B10
-        block_folder = 'RVG16_B02'
+        # new test blocks: RVG16_{B02, B04, B05, B06, B07, B08, B09, B10}
+        #                       B02, B04, B05: tone diagnostic (no metadata yaml)
+        #                       B06: unable to open file Tone/Tone.stimVls.mat
+        #                       B07: unable to open file Tone150/Tone150.stimVls.mat
+        #                       B08: FileNotFoundError TIMIT/timit998.txt
+        #                       B09: stimulus type 'nan' not found
+        #                       B10: ValueError: Unknown stimulus type '{stim_name}' for mark tokenizer
+        # legacy test block: R56_B10: metadata yaml not found in data_path
+        block_folder = 'R56_B10'
         use_htk = False
         # --------------------------------------------------------------
         self.__build_nwb_content(block_folder, use_htk)

--- a/tests/test_stim_value_extractor.py
+++ b/tests/test_stim_value_extractor.py
@@ -25,6 +25,10 @@ class TestCase_StimValueExtractor(unittest.TestCase):
         stim_name = 'wn2'
         stim_values = self.__test_stim(stim_name)
 
+    def test_tone(self):
+        stim_name = 'tone'
+        stim_values = self.__test_stim(stim_name)
+
     def test_tone150(self):
         stim_name = 'tone150'
         stim_values = self.__test_stim(stim_name)

--- a/tests/test_stim_value_extractor.py
+++ b/tests/test_stim_value_extractor.py
@@ -21,16 +21,19 @@ class TestCase_StimValueExtractor(unittest.TestCase):
         stim_values = sve.extract()
         return stim_values
 
-    def test_wn2(self):
+    def test_white_noise_stimuli(self):
         stim_name = 'wn2'
         stim_values = self.__test_stim(stim_name)
 
-    def test_tone(self):
+    def test_tone_stimuli(self):
         stim_name = 'tone'
         stim_values = self.__test_stim(stim_name)
 
-    def test_tone150(self):
         stim_name = 'tone150'
+        stim_values = self.__test_stim(stim_name)
+
+    def test_timit_stimuli(self):
+        stim_name = 'timit'
         stim_values = self.__test_stim(stim_name)
 
 

--- a/tests/test_stim_value_extractor.py
+++ b/tests/test_stim_value_extractor.py
@@ -36,6 +36,11 @@ class TestCase_StimValueExtractor(unittest.TestCase):
         stim_name = 'timit'
         stim_values = self.__test_stim(stim_name)
 
+    def test_dmr_stimuli(self):
+        stim_name = 'dmr'
+        stim_values = self.__test_stim(stim_name)
+        assert stim_values is None
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_stim_value_extractor.py
+++ b/tests/test_stim_value_extractor.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+
+from nsds_lab_to_nwb.common.io import read_yaml
+from nsds_lab_to_nwb.components.stimulus.stim_value_extractor import StimValueExtractor
+from nsds_lab_to_nwb.metadata.stim_name_helper import check_stimulus_name
+from nsds_lab_to_nwb.utils import get_stim_lib_path, get_metadata_lib_path
+
+
+class TestCase_StimValueExtractor(unittest.TestCase):
+
+    stim_lib_path = get_stim_lib_path()
+    metadata_lib_path = get_metadata_lib_path()
+
+    def __test_stim(self, stim_name_input):
+        stim_name, stim_info = check_stimulus_name(stim_name_input)
+        stim_yaml_path = os.path.join(self.metadata_lib_path, 'auditory', 'yaml',
+                                      'stimulus', stim_name + '.yaml')
+        stim_configs = read_yaml(stim_yaml_path)
+        sve = StimValueExtractor(stim_configs, self.stim_lib_path)
+        stim_values = sve.extract()
+        return stim_values
+
+    def test_wn2(self):
+        stim_name = 'wn2'
+        stim_values = self.__test_stim(stim_name)
+
+    def test_tone150(self):
+        stim_name = 'tone150'
+        stim_values = self.__test_stim(stim_name)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description and related issues

Now successfully processes (tone, tone150, timit, dmr, nan, wn2) without neural data resampling; tone_diagnostic needs additional input in `list_of_stimuli.yaml`.

Includes Jesse's commits (manual rebase) from PR #69 .

Should be reviewed at the same time with a PR to the metadata library repo (below)

Partially addresses issues #71 and #72 .

# Changes outside this repo:

- **Metadata library** — co-developing with this PR in the metadata repo
    - https://github.com/BouchardLab/NSDSLab-NWB-metadata/pull/6
  
  Did _not_ pull this PR in the catscan metadata repo `/clusterfs/NSDS_data/NSDSLab-NWB-metadata/`

- **Stimulus library**
    - Added `/clusterfs/NSDS_data/stimuli/Tone/Tone.stimVls.mat` (copied from `mars.configs`)

# Status:

Test blocks that were failing before this PR:

    # --------------------------------------------------------------
    # new test blocks: RVG16_{B02, B04, B05, B06, B07, B08, B09, B10}
    #     - B02, B04, B05: tone_diagnostic (no associated files in list_of_stimuli.yaml)
    #     - B06: Tone                                <<<<<<< now passes with resample_data=False
    #     - B07: Tone150                             <<<<<<< now passes with resample_data=False
    #     - B08: TIMIT                               <<<<<<< now passes with resample_data=False
    #     - B09: stimulus 'nan'                      <<<<<<< now passes (handled by Stopping gracefully)
    #     - B10: dmr                                 <<<<<<< now passes (handled by not tokenizing)
    # legacy test block: R56_B10: metadata yaml not found in data_path
    # ———————————————————————————————


# Checklist:

- [ ] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory
- [x] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files - N/A
- [x] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [ ] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory
