### PR TITLE
more fixes to stimulus processing

### DIFF
--- a/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
+++ b/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
@@ -47,7 +47,10 @@ class StimValueExtractor():
             return os.path.join(self.stim_lib_path, path_from_los)
 
         # if empty path in list_of_stimuli.yaml, use metadata input
-        return os.path.join(self.stim_lib_path, path_from_metadata)
+        if path_from_metadata is not None:
+            return os.path.join(self.stim_lib_path, path_from_metadata)
+
+        return ValueError('No input for the path to stim parameterization info')
 
 
 def tone_stimulus_values(mat_file_path):

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/timit_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/timit_tokenizer.py
@@ -35,7 +35,7 @@ class TIMITTokenizer(StimulusTokenizer):
         # TODO: Assert that the # of stim vals is equal to the number of found onsets
         assert len(stim_onsets)==len(stim_vals), (
                     "Incorrect number of stimulus onsets found."
-                    + " Expected {:d}, found {:d}.".format(stim_vals.shape[1],len(stim_onsets))
+                    + " Expected {:d}, found {:d}.".format(len(stim_vals), len(stim_onsets))
                     + " Perhaps you are not using the correct tokenizer?"
                     )
         for i, onset in enumerate(stim_onsets):
@@ -54,7 +54,7 @@ class TIMITTokenizer(StimulusTokenizer):
                 'amp' in nwb_content.trials.colnames)
 
     def __get_stim_onsets(self, nwb_content, mark_name):
-        mark_dset = self.read_mark(mark_name)
+        mark_dset = self.read_mark(nwb_content, mark_name)
         mark_fs = mark_dset.rate
         mark_offset = self.stim_configs['mark_offset']
         stim_dur = self.stim_configs['duration']

--- a/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
@@ -49,10 +49,10 @@ dmr:
 
 tone_diagnostic:
     alt_names: ['Tone diagnostic']
-    description: '' #Vanessa can you please add a description, copy files to catscan and add paths (if the files exist)
-    audio_path: ''
-    marker_path: ''
-    parameter_path: ''
+    description: ''
+    audio_path: 'ToneDiagnostic/tonediagnostic_s.wav'
+    marker_path: 'ToneDiagnostic/tonediagnostic_t.wav'
+    parameter_path: 'ToneDiagnostic/Tone_diag_stim.stimVls.mat'
 
 baseline:
     alt_names: ['Baseline']

--- a/tests/test_build_nwb.py
+++ b/tests/test_build_nwb.py
@@ -13,22 +13,11 @@ class TestCase_Build_NWB(unittest.TestCase):
     metadata_save_path = '_test/'
     out_path = '_test/'
 
-    # --------------------------------------------------------------
-    # currently failing blocks:
-    # new test blocks: RVG16_{B02, B04, B05, B06, B07, B08, B09, B10}
-    #     - B02, B04, B05: tone_diagnostic (no associated files in list_of_stimuli.yaml)
-    #     - B06: Tone                                <<<<<<< now passes with resample_data=False
-    #     - B07: Tone150                             <<<<<<< now passes with resample_data=False
-    #     - B08: TIMIT                               <<<<<<< now passes with resample_data=False
-    #     - B09: stimulus 'nan'                      <<<<<<< now passes (handled by Stopping gracefully)
-    #     - B10: dmr                                 <<<<<<< now passes (handled by not tokenizing)
-    # legacy test block: R56_B10: metadata yaml not found in data_path
-    # --------------------------------------------------------------
-
     def test_build_nwb_single_block(self):
         ''' build NWB but do not write file to disk '''
-        block_folder = 'RVG16_B10'
+        block_folder = 'RVG16_B08'
         resample_data = False   # for testing
+        # resample_data = True
         use_htk = False
         self.__build_nwb_content(block_folder, resample_data, use_htk)
 

--- a/tests/test_catscan.py
+++ b/tests/test_catscan.py
@@ -3,11 +3,12 @@ from nsds_lab_to_nwb.nwb_builder import NWBBuilder
 from nsds_lab_to_nwb.utils import (split_block_folder, get_data_path,
                                    get_metadata_lib_path)
 
-
 # Set to standard catscan locations (ignore any personal settings)
-os.environ['NSDS_DATA_PATH'] = '/clusterfs/NSDS_data/raw'
-os.environ['NSDS_METADATA_PATH'] = '/clusterfs/NSDS_data/NSDSLab-NWB-metadata'
-os.environ['NSDS_STIMULI_PATH'] = '/clusterfs/NSDS_data/stimuli'
+os.environ['NSDS_DATA_PATH'] = '/clusterfs/NSDS_data/raw/'
+os.environ['NSDS_METADATA_PATH'] = '/clusterfs/NSDS_data/NSDSLab-NWB-metadata/'
+os.environ['NSDS_STIMULI_PATH'] = '/clusterfs/NSDS_data/stimuli/'
+
+RESAMPLE_DATA = True
 
 
 @pytest.mark.parametrize("block_folder", [("RVG16_B01"),
@@ -33,7 +34,8 @@ def test_nwb_builder(tmpdir, block_folder):
         data_path=data_path,
         block_folder=block_folder,
         save_path=tmpdir,
-        block_metadata_path=block_metadata)
+        block_metadata_path=block_metadata,
+        resample_data=RESAMPLE_DATA)
 
     # build the NWB file content
     nwb_content = nwb_builder.build()
@@ -49,7 +51,6 @@ def test_legacy_nwb_builder(tmpdir, block_folder):
     if not os.path.isdir(os.environ['NSDS_DATA_PATH']):
         pytest.xfail('Testing data folder on catscan not found')
 
-
     _, animal_name, _ = split_block_folder(block_folder)
     data_path = get_data_path()
     metadata_path = get_metadata_lib_path()
@@ -60,7 +61,8 @@ def test_legacy_nwb_builder(tmpdir, block_folder):
         data_path=data_path,
         block_folder=block_folder,
         save_path=tmpdir,
-        block_metadata_path=block_metadata)
+        block_metadata_path=block_metadata,
+        resample_data=RESAMPLE_DATA)
 
     # build the NWB file content
     nwb_content = nwb_builder.build()


### PR DESCRIPTION
Remaining stim pipeline error fixes that were missed in the recently closed PR #85 .

Output from running `pytest --basetemp=tmp -sv -n 12 test_catscan.py`:

- With `RESAMPLE_DATA=True` in the updated `test_catscan.py`, getting some memory errors. (I used `-n 12` though; will try using a smaller n)

    ```python
    ==================================== short test summary info =====================================
    FAILED test_catscan.py::test_nwb_builder[RVG16_B07] - numpy.core._exceptions._ArrayMemoryError:...
    FAILED test_catscan.py::test_nwb_builder[RVG16_B08] - numpy.core._exceptions._ArrayMemoryError:...
    FAILED test_catscan.py::test_nwb_builder[RVG16_B06] - numpy.core._exceptions._ArrayMemoryError:...
    FAILED test_catscan.py::test_legacy_nwb_builder[R56_B10] - numpy.core._exceptions._ArrayMemoryE...
    FAILED test_catscan.py::test_nwb_builder[RVG16_B10] - numpy.core._exceptions._ArrayMemoryError:...
    ======================= 5 failed, 7 passed, 1 warning in 364.89s (0:06:04) =======================
    ```

    - Update: serial run (no `-n` option) still fails for some blocks, and this was on n0001

        ```python
        ==================================== short test summary info =====================================
        FAILED test_catscan.py::test_nwb_builder[RVG16_B07] - numpy.core._exceptions._ArrayMemoryError:...
        FAILED test_catscan.py::test_nwb_builder[RVG16_B08] - MemoryError
        FAILED test_catscan.py::test_nwb_builder[RVG16_B10] - numpy.core._exceptions._ArrayMemoryError:...
        ====================== 3 failed, 9 passed, 1 warning in 7126.49s (1:58:46) =======================
        ```


- With `RESAMPLE_DATA=False`, all passing except TIMIT block (number of stim onsets mismatch)

    ```python
    ==================================== short test summary info =====================================
    FAILED test_catscan.py::test_nwb_builder[RVG16_B08] - AssertionError: Incorrect number of stimu...
    ====================== 1 failed, 11 passed, 1 warning in 339.06s (0:05:39) =======================
    ```

    This is the full error message, and it is coming from TIMIT tokenizer around L36:

    ```python
    AssertionError: Incorrect number of stimulus onsets found. Expected 998, found 637. Perhaps you are not using the correct tokenizer?
    ```