### PR TITLE
fix exp_note path parsing error in MetadataManager

### DIFF
--- a/nsds_lab_to_nwb/metadata/metadata_manager.py
+++ b/nsds_lab_to_nwb/metadata/metadata_manager.py
@@ -54,8 +54,10 @@ class MetadataReader:
             metadata_input = read_yaml(self.block_metadata_path)
         except FileNotFoundError:
             # first generate the block metadata file
-            experiment_path, block_metadata_file = os.path.split(self.block_metadata_path)
+            block_path_full, block_metadata_file = os.path.split(self.block_metadata_path)
+            experiment_path, _ = os.path.split(block_path_full)
             block_folder, ext = os.path.splitext(block_metadata_file)
+            logger.debug(f'Looking for an experiment note file in {experiment_path}...')
             reader = ExpNoteReader(experiment_path, block_folder)
             reader.dump_yaml(write_path=self.block_metadata_path)
             # then try reading again


### PR DESCRIPTION
Another quick bug-fix PR. This fixes a path parsing error in MetadataManager, when it attempts to look for an Experiment_Notes file (when the block metadata yaml is not already available).

The (corrected) parsing code in `MetadataReader.load_metadata_source()` does

```python
block_path_full, block_metadata_file = os.path.split(self.block_metadata_path)
experiment_path, _ = os.path.split(block_path_full)
...
```

For example if the block is `RVG21_B10`, the parsed paths are

```
block_metadata_path = '/somepath/RVG21/RVG21_B10/RVG21_B10.yaml'

# split once
block_path_full = '/somepath/RVG21/RVG21_B10/'
block_metadata_file = 'RVG21_B10.yaml'

# split again
experiment_path = '/somepath/RVG21/'
```

We are expecting to find a `RVG21_Experiment_Notes.ods` file under the `experiment_path`.

Before the fix, the `experiment_path` was incorrectly parsed to be `/somepath/RVG21/RVG21_B10/` (split only once).
