### PR TITLE
Fixed auto yaml dump behavior

### DIFF
--- a/nsds_lab_to_nwb/metadata/exp_note_reader.py
+++ b/nsds_lab_to_nwb/metadata/exp_note_reader.py
@@ -185,12 +185,18 @@ class ExpNoteReader():
         write_path : str, optional
             Path to write yaml file, by default None
             If None writes to self.path
+        
+        Returns
+        -------
+        write_path_file : path
+            path file to written yaml
         """
         if write_path is None:
             write_path = self.path
         nsds_meta = self.get_nsds_meta()
         write_path_file = os.path.join(write_path, self.block_folder + '.yaml')
         write_yaml(write_path_file, nsds_meta, sort_keys=True)
+        return write_path_file
 
     def get_nsds_meta(self):
         """Get parsed data

--- a/nsds_lab_to_nwb/metadata/metadata_manager.py
+++ b/nsds_lab_to_nwb/metadata/metadata_manager.py
@@ -52,14 +52,12 @@ class MetadataReader:
     def load_metadata_source(self):
         try:
             metadata_input = read_yaml(self.block_metadata_path)
-        except FileNotFoundError:
+        except (FileNotFoundError, IsADirectoryError):
             # first generate the block metadata file
-            block_path_full, block_metadata_file = os.path.split(self.block_metadata_path)
-            experiment_path, _ = os.path.split(block_path_full)
-            block_folder, ext = os.path.splitext(block_metadata_file)
-            logger.debug(f'Looking for an experiment note file in {experiment_path}...')
-            reader = ExpNoteReader(experiment_path, block_folder)
-            reader.dump_yaml(write_path=self.block_metadata_path)
+            logger.debug(f'Looking for an experiment note file in {self.block_metadata_path}...')
+            reader = ExpNoteReader(self.block_metadata_path, self.block_folder)
+            yaml_path_file = reader.dump_yaml()
+            self.block_metadata_path = yaml_path_file
             # then try reading again
             metadata_input = read_yaml(self.block_metadata_path)
         return metadata_input

--- a/nsds_lab_to_nwb/nwb_builder.py
+++ b/nsds_lab_to_nwb/nwb_builder.py
@@ -68,7 +68,7 @@ class NWBBuilder:
         self.surgeon_initials, self.animal_name, self.block_name = split_block_folder(block_folder)
         self.block_folder = block_folder
         self.save_path = save_path
-        self.block_metadata_path = block_metadata_path
+        self.block_metadata_path = self._get_block_metadata_path(block_metadata_path)
         self.stim_lib_path = stim_lib_path
         self.metadata_save_path = metadata_save_path
         self.resample_data = resample_data
@@ -108,6 +108,12 @@ class NWBBuilder:
         logger.info('Extracting session start time...')
         self.session_start_time = self._extract_session_start_time()
 
+    def _get_block_metadata_path(self, path):
+        if path is None:
+            surgeon, animal, block = split_block_folder(self.block_folder)
+            path = os.path.join(self.data_path, animal)
+        return path
+    
     def _get_source_script(self):
         info = get_software_info()
         if info['git_branch'] != 'main':

--- a/scripts/generate_nwb.py
+++ b/scripts/generate_nwb.py
@@ -15,7 +15,8 @@ with path(nsds_lab_to_nwb, 'logging.conf') as fname:
 parser = argparse.ArgumentParser(description='Convert to a NWB file.')
 parser.add_argument('save_path', type=str, help='Path to save the NWB file.')
 parser.add_argument('block_folder', type=str, help='<animal>_<block> block specification.')
-parser.add_argument('block_metadata_path', type=str, help='Path to block metadata file.')
+parser.add_argument('--block_metadata_path', '-e', type=str, default=None,
+                    help='Path to block metadata file.')
 parser.add_argument('--data_path', '-d', type=str, default=None,
                     help='Path to the top level data folder.')
 parser.add_argument('--metadata_lib_path', '-m', type=str, default=None,


### PR DESCRIPTION
# Description and related issues

Currently, the user needs to specify the block metadata yaml file path, which is annoying. I propose making this an optional argument in `generate_nwb.py` where the default value is `None`. In `nwb_builder.py`, if `None` is detected, it files in a good default path to look for metadata files. In the `metadata_manager` this will fail and trigger the except block to look for experiment notes and then dump those as a yaml (if found of course).

I tested this locally and it passes. 

Closes #(issue number)

# Checklist:

- [ ] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory 
- [ ] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [ ] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [ ] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory
