### PR TITLE
fix bad_chs format, handle baseline block

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,29 @@ Also install this package:
 pip install -e .
 ```
 
-Some test scripts also assume that you have cloned the metadata repository:
-(Bouchard lab internal access only)
+### Setting the default paths
 
+It is recommended to set the default data, metadata and stimulus paths
+as the environment variables.
+
+If you are running this on catscan, open your `~/.bashrc` file in any text editor,
+and copy and paste the following lines into the `~/.bashrc` file.
+
+```bash
+export NSDS_METADATA_PATH='/clusterfs/NSDS_data/NSDSLab-NWB-metadata/'
+export NSDS_DATA_PATH='/clusterfs/NSDS_data/raw/'
+export NSDS_STIMULI_PATH='/clusterfs/NSDS_data/stimuli/'
+```
+
+If you are not on catscan, you should make sure that the values of the three environment variables are set correctly, such that the software can find the data, metadata and stimulus files.
+You will need to clone the [NSDSLab-NWB-metadata repository](https://github.com/BouchardLab/NSDSLab-NWB-metadata) and make sure that `NSDS_METADATA_PATH` points to the repository.
+
+<!--
 ```bash
 mkdir -p ~/Src
 cd ~/Src
 git clone git@github.com:BouchardLab/NSDSLab-NWB-metadata.git
 ```
+-->
+
+Also see the [Naming Conventions documentation](https://nsds-lab-to-nwb.readthedocs.io/en/latest/naming_conventions.html) for more information.

--- a/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
+++ b/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
@@ -34,7 +34,8 @@ class StimulusOriginator():
         # add stimulus WAV data
         stim_starting_time = self._get_stim_starting_time(nwb_content)
         stim_wav_time_series = self.wav_manager.get_stim_wav(starting_time=stim_starting_time)
-        nwb_content.add_stimulus(stim_wav_time_series)
+        if stim_wav_time_series is not None:
+            nwb_content.add_stimulus(stim_wav_time_series)
 
     def _get_stim_starting_time(self, nwb_content):
         if self.trials_manager.tokenizable:

--- a/nsds_lab_to_nwb/components/stimulus/wav_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/wav_manager.py
@@ -1,10 +1,15 @@
+import logging
 import os
+import numpy as np
 from scipy.io import wavfile
 
 from pynwb import TimeSeries
 
 from nsds_lab_to_nwb.metadata.stim_name_helper import check_stimulus_name
 from nsds_lab_to_nwb.utils import get_stim_lib_path
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class WavManager():
@@ -16,16 +21,23 @@ class WavManager():
     def get_stim_wav(self, starting_time, name='raw_stimulus'):
         if self.stim_name == 'wn1':
             return None
-        return self._get_stim_wav(self.get_stim_file(self.stim_name, self.stim_lib_path),
-                                  starting_time, name=name)
+
+        stim_file = self.get_stim_file(self.stim_name, self.stim_lib_path)
+        if stim_file is None:
+            logger.info(f'Stimulus [{self.stim_name}] has no audio file. ' +
+                        'No stimulus will be added to the NWB file.')
+            return None
+
+        logger.debug(f'Loading stimulus from: {stim_file}')
+        return self._get_stim_wav(stim_file, starting_time, name=name)
 
     def _get_stim_wav(self, stim_file, starting_time, name='raw_stimulus'):
         ''' get the raw wav stimulus track '''
         # Read the stimulus wav file
         stim_wav_fs, stim_wav = wavfile.read(stim_file)
+        rate = float(stim_wav_fs)
 
         # Create the stimulus timeseries
-        rate = float(stim_wav_fs)
         stim_time_series = TimeSeries(name=name,
                                       data=stim_wav,
                                       starting_time=starting_time,
@@ -37,4 +49,7 @@ class WavManager():
     @staticmethod
     def get_stim_file(stim_name, stim_path):
         _, stim_info = check_stimulus_name(stim_name)
+        if stim_info['audio_path'] is None:
+            # when there is no associated audio file (e.g., baseline)
+            return None
         return os.path.join(stim_path, stim_info['audio_path'])

--- a/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
@@ -57,6 +57,6 @@ tone_diagnostic:
 baseline:
     alt_names: ['Baseline']
     description: 'No stimulus'
-    audio_path: ''
-    marker_path: ''
-    parameter_path: ''
+    audio_path: null
+    marker_path: null
+    parameter_path: null

--- a/nsds_lab_to_nwb/metadata/resources/metadata_keymap.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/metadata_keymap.yaml
@@ -191,7 +191,7 @@ keymap:
 
 - name: poly_bad_chs
   comes_from: block_metadata
-  mapto: device.ECoG.bad_chs
+  mapto: device.Poly.bad_chs
   description: ''
 
 - name: clean_block

--- a/scripts/block_test.sh
+++ b/scripts/block_test.sh
@@ -9,6 +9,9 @@
 # Or turn off resample_data as well:
 # ./block_test RVG16_B01 --write_nwb False --resample_data False
 #
+# For a quick test run with both write_nwb and resample_data set to False:
+# ./block_test RVG16_B01 --test_run
+#
 # See generate_nwb.py to learn about more input arguments options.
 # -----------------------------------------------------------------
 

--- a/tests/test_catscan.py
+++ b/tests/test_catscan.py
@@ -11,16 +11,19 @@ os.environ['NSDS_STIMULI_PATH'] = '/clusterfs/NSDS_data/stimuli/'
 RESAMPLE_DATA = True
 
 
-@pytest.mark.parametrize("block_folder", [("RVG16_B01"),
-                                          ("RVG16_B02"),
-                                          ("RVG16_B03"),
-                                          ("RVG16_B04"),
-                                          ("RVG16_B05"),
-                                          ("RVG16_B06"),
-                                          ("RVG16_B07"),
-                                          ("RVG16_B08"),
-                                          ("RVG16_B09"),
-                                          ("RVG16_B10")])
+@pytest.mark.parametrize("block_folder", [("RVG16_B01"),  # wn2
+                                          ("RVG16_B02"),  # tone_diagnostic
+                                          ("RVG16_B03"),  # wn2
+                                          ("RVG16_B04"),  # tone_diagnostic
+                                          ("RVG16_B05"),  # tone_diagnostic
+                                          ("RVG16_B06"),  # tone
+                                          ("RVG16_B07"),  # tone150
+                                          ("RVG16_B08"),  # TIMIT, *bad block*
+                                          ("RVG16_B09"),  # no stim, *bad block*
+                                          ("RVG16_B10"),  # dmr
+                                          ("RVG21_B12"),  # baseline stim
+                                          ("RVG21_B13"),  # TIMIT
+                                         ])
 def test_nwb_builder(tmpdir, block_folder):
     """Runs the NWB pipline on a block."""
     if not os.path.isdir(os.environ['NSDS_DATA_PATH']):


### PR DESCRIPTION
# Description

- add new test blocks `RVG21_B12` (baseline block) and `RVG21_B13` (TIMIT block) to `tests/test_catscan.py`, and confirm that they can be processed up to resampling
- autocorrect input format for bad_chs (currently stored as comma-separated ints, which is interpreted as a string by yaml; unpack into a list of integers)
- handle baseline block: no stimulus TimeSeries is added to the NWB file.

# Related issues

- Close #72 
- Close #99
- (#96 is probably also fixed by this, although not explicitly linked)

# What I did to test:

These run without errors:

```bash
./scripts/block_test.sh RVG21_B12 --test_run
./scripts/block_test.sh RVG21_B13 --test_run
```

The `--test_run` option sets both `write_nwb` and `resample_data` to False.

# Checklist:

- [x] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory
    - partial YES (with `resample_data=False`)
    - some blocks fail with resampling, but that's a known separate issue
- [x] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [x] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [ ] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory