### PR TITLE
fix stimulus, marks and trials

### DIFF
--- a/docs/source/nsds_lab_to_nwb/components/stimulus.rst
+++ b/docs/source/nsds_lab_to_nwb/components/stimulus.rst
@@ -31,6 +31,11 @@ components.stimulus API
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: nsds_lab_to_nwb.components.stimulus.tokenizers.single_tokenizer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: nsds_lab_to_nwb.components.stimulus.tokenizers.timit_tokenizer
    :members:
    :undoc-members:

--- a/nsds_lab_to_nwb/components/stimulus/mark_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/mark_manager.py
@@ -19,7 +19,11 @@ class MarkManager():
             tdt_reader = TDTReader(self.dataset.tdt_path)
             mark_track, meta = tdt_reader.get_data(stream='mrk1')
             rate = meta['sample_rate']
-            mark_onsets = tdt_reader.get_events()
+            try:
+                mark_onsets = tdt_reader.get_events()
+            except AttributeError:
+                # there is no mark for baseline (no stimulus) block
+                mark_onsets = None
 
         # Create the mark timeseries
         mark_time_series = TimeSeries(name=name,

--- a/nsds_lab_to_nwb/components/stimulus/mark_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/mark_manager.py
@@ -27,6 +27,6 @@ class MarkManager():
                                       unit='Volts',
                                       starting_time=starting_time,
                                       rate=rate,
-                                      description='The stimulus mark track.')
+                                      description='Recorded mark that tracks stimulus onsets.')
 
         return mark_time_series, mark_onsets

--- a/nsds_lab_to_nwb/components/stimulus/mark_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/mark_manager.py
@@ -14,9 +14,12 @@ class MarkManager():
             mark_file = HTKFile(self.dataset.htk_mark_path)
             mark_track, meta = mark_file.read_data()
             rate = mark_file.sample_rate
+            mark_onsets = None
         else:
-            mark_track, meta = TDTReader(self.dataset.tdt_path).get_data(stream='mrk1')
+            tdt_reader = TDTReader(self.dataset.tdt_path)
+            mark_track, meta = tdt_reader.get_data(stream='mrk1')
             rate = meta['sample_rate']
+            mark_onsets = tdt_reader.get_events()
 
         # Create the mark timeseries
         mark_time_series = TimeSeries(name=name,
@@ -25,4 +28,5 @@ class MarkManager():
                                       starting_time=starting_time,
                                       rate=rate,
                                       description='The stimulus mark track.')
-        return mark_time_series
+
+        return mark_time_series, mark_onsets

--- a/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
+++ b/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
@@ -34,12 +34,12 @@ class StimulusOriginator():
         # add mark track
         logger.info('Adding marks...')
         mark_starting_time = 0.0    # see issue #88 for discussion
-        mark_time_series = self.mark_manager.get_mark_track(starting_time=mark_starting_time)
+        mark_time_series, mark_onsets = self.mark_manager.get_mark_track(starting_time=mark_starting_time)
         nwb_content.add_stimulus(mark_time_series)
 
         # tokenize into trials, once mark track has been added to nwb_content
         logger.info('Tokenizing into trials...')
-        self.trials_manager.add_trials(nwb_content, self.stim_vals)
+        self.trials_manager.add_trials(nwb_content, mark_onsets, self.stim_vals)
 
         # add stimulus WAV data
         logger.info('Adding stimulus waveform...')

--- a/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
+++ b/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
@@ -33,7 +33,7 @@ class StimulusOriginator():
 
         # add mark track
         logger.info('Adding marks...')
-        mark_starting_time = 0.0    # <<<< legacy behavior. confirm! always at 0.0?
+        mark_starting_time = 0.0    # see issue #88 for discussion
         mark_time_series = self.mark_manager.get_mark_track(starting_time=mark_starting_time)
         nwb_content.add_stimulus(mark_time_series)
 
@@ -51,11 +51,10 @@ class StimulusOriginator():
     def _get_stim_starting_time(self, nwb_content):
         if self.trials_manager.tokenizable:
             time_table = nwb_content.trials.to_dataframe().query('sb == "s"')['start_time']
-            # first_recorded_mark = time_table[1]  # <<< this was MARS version; legacy from matlab code?
             first_recorded_mark = time_table.values[0]
         else:
             # continuous stimulus
-            first_recorded_mark = 0.0    # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< just a guess. confirm!!!
+            first_recorded_mark = 0.0    # see issue #88 for discussion
 
         # starting time for the stimulus TimeSeries
         stim_starting_time = (first_recorded_mark

--- a/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
+++ b/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
@@ -56,11 +56,11 @@ class StimulusOriginator():
             nwb_content.add_stimulus(stim_wav_time_series)
 
     def _get_stim_starting_time(self, nwb_content):
-        if self.trials_manager.tokenizable:
+        try:
             time_table = nwb_content.trials.to_dataframe().query('sb == "s"')['start_time']
             first_recorded_mark = time_table.values[0]
-        else:
-            # continuous stimulus
+        except IndexError:
+            # there may be no 's' trial if it was a 'baseline' stimulus block
             first_recorded_mark = 0.0    # see issue #88 for discussion
 
         # starting time for the stimulus TimeSeries

--- a/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
+++ b/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
@@ -26,6 +26,10 @@ class StimulusOriginator():
         self.wav_manager = WavManager(self.stim_lib_path,
                                       self.stim_configs)
 
+        # names for mark and stimulus time series objects
+        self.mark_obj_name = 'stim_onset_marks'  # 'recorded_mark' (previous name)
+        self.stim_wav_obj_name = 'stim_waveform'  # 'raw_stimulus' (previous name)
+
     def make(self, nwb_content):
         stim_name = self.stim_configs['name']
         stim_type = self.stim_configs['type']  # either 'discrete' or 'continuous'
@@ -34,17 +38,20 @@ class StimulusOriginator():
         # add mark track
         logger.info('Adding marks...')
         mark_starting_time = 0.0    # see issue #88 for discussion
-        mark_time_series, mark_onsets = self.mark_manager.get_mark_track(starting_time=mark_starting_time)
+        mark_time_series, mark_onsets = self.mark_manager.get_mark_track(starting_time=mark_starting_time,
+                                                                         name=self.mark_obj_name)
         nwb_content.add_stimulus(mark_time_series)
 
         # tokenize into trials, once mark track has been added to nwb_content
         logger.info('Tokenizing into trials...')
-        self.trials_manager.add_trials(nwb_content, mark_onsets, self.stim_vals)
+        self.trials_manager.add_trials(nwb_content, mark_onsets, self.stim_vals,
+                                       mark_obj_name=self.mark_obj_name)
 
         # add stimulus WAV data
         logger.info('Adding stimulus waveform...')
         stim_starting_time = self._get_stim_starting_time(nwb_content)
-        stim_wav_time_series = self.wav_manager.get_stim_wav(starting_time=stim_starting_time)
+        stim_wav_time_series = self.wav_manager.get_stim_wav(starting_time=stim_starting_time,
+                                                             name=self.stim_wav_obj_name)
         if stim_wav_time_series is not None:
             nwb_content.add_stimulus(stim_wav_time_series)
 

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/base_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/base_tokenizer.py
@@ -54,6 +54,8 @@ class BaseTokenizer():
         return stim_onsets_idx
 
     def _get_mark_threshold(self):
+        # NOTE: this is only used when TDT-loaded mark onsets are not available.
+        # see issue #102 for more discussion on mark thresholds.
         mark_threshold = self.stim_configs['mark_threshold']
         logger.debug(f'using mark_threshold={mark_threshold} from metadata input')
         return mark_threshold

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/base_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/base_tokenizer.py
@@ -15,8 +15,8 @@ class BaseTokenizer():
         self.tokenizer_type = 'BaseTokenizer'
         self.custom_trial_columns = None
 
-    def tokenize(self, mark_time_series, stim_vals):
-        stim_onsets = self.get_stim_onsets(mark_time_series)
+    def tokenize(self, mark_onsets, mark_time_series, stim_vals):
+        stim_onsets = self.get_stim_onsets(mark_onsets, mark_time_series)
         self._validate_num_stim_onsets(stim_vals, stim_onsets)
         rec_end_time = mark_time_series.num_samples / mark_time_series.rate
         trial_list = self._tokenize(stim_vals, stim_onsets,
@@ -29,7 +29,13 @@ class BaseTokenizer():
     def _tokenize(self, mark_time_series, rec_end_time):
         raise NotImplementedError
 
-    def get_stim_onsets(self, mark_time_series):
+    def get_stim_onsets(self, mark_onsets, mark_time_series):
+        if mark_onsets is not None:
+            # loaded directly from TDT object
+            logger.info('Using stimulus onsets directly loaded from TDT')
+            return mark_onsets
+
+        logger.info('Detecting stimulus onsets by thresholding the mark track')
         mark_fs = mark_time_series.rate
         mark_offset = self.stim_configs['mark_offset']
         mark_threshold = self._get_mark_threshold()

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/base_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/base_tokenizer.py
@@ -26,7 +26,8 @@ class BaseTokenizer():
                                     rec_end_time=rec_end_time)
         return trial_list
 
-    def _tokenize(self, mark_time_series, rec_end_time):
+    def _tokenize(self, stim_vals, stim_onsets,
+                  *, stim_dur, bl_start, bl_end, rec_end_time):
         raise NotImplementedError
 
     def get_stim_onsets(self, mark_onsets, mark_time_series):

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/single_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/single_tokenizer.py
@@ -1,0 +1,35 @@
+from nsds_lab_to_nwb.components.stimulus.tokenizers.base_tokenizer import BaseTokenizer
+
+
+class SingleTokenizer(BaseTokenizer):
+    """
+    Tokenize into a single trial, for stimulus data of type 'continuous'.
+    """
+    def __init__(self, block_name, stim_configs):
+        BaseTokenizer.__init__(self, block_name, stim_configs)
+        self.tokenizer_type = 'SingleTokenizer'
+
+        # list of ('column_name', 'column_description')
+        self.custom_trial_columns = [('sb', 'Stimulus (s) or baseline (b) period'),
+                                     ('stim_name', 'Stimulus name')]
+
+    def tokenize(self, mark_onsets, mark_time_series, stim_vals):
+        stim_onsets = None  # not needed in this case
+        rec_end_time = mark_time_series.num_samples / mark_time_series.rate
+        trial_list = self._tokenize(stim_vals, stim_onsets,
+                                    rec_end_time=rec_end_time)
+        return trial_list
+
+    def _tokenize(self, stim_vals, stim_onsets, *, rec_end_time):
+        stim_name = self.stim_configs['name']
+        if stim_name == 'baseline':
+            sb = 'b'
+        else:
+            sb = 's'
+
+        # add single trial
+        trial_list = [dict(start_time=0.0,
+                           stop_time=rec_end_time,
+                           sb=sb,
+                           stim_name=stim_name)]
+        return trial_list

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/wn_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/wn_tokenizer.py
@@ -68,13 +68,8 @@ class WNTokenizer(BaseTokenizer):
         return stim_onsets_idx
 
     def _get_mark_threshold(self):
-        # ---------------------------------------------------------------------
-        # if 'wn2' in self.stim_configs['name']:
-        #     # for now hard-coding this threshold for WN2 - confirm!
-        #     mark_threshold = 0.1  # arbitrary value, but this seems to work for wn2 (RVG16_B01)
-        #     logger.debug(f'using mark_threshold={mark_threshold} (hard-coded for WN2)')
-        #     return mark_threshold
-        # ---------------------------------------------------------------------
+        # NOTE: this is only used when TDT-loaded mark onsets are not available.
+        # see issue #102 for more discussion on mark thresholds.
 
         if self.stim_configs.get('mark_is_stim', False):
             # NOTE: this is true for stimulus wn1, but not wn2

--- a/nsds_lab_to_nwb/components/stimulus/trials_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/trials_manager.py
@@ -1,5 +1,6 @@
 import logging
 
+from nsds_lab_to_nwb.components.stimulus.tokenizers.single_tokenizer import SingleTokenizer
 from nsds_lab_to_nwb.components.stimulus.tokenizers.tone_tokenizer import ToneTokenizer
 from nsds_lab_to_nwb.components.stimulus.tokenizers.timit_tokenizer import TIMITTokenizer
 from nsds_lab_to_nwb.components.stimulus.tokenizers.wn_tokenizer import WNTokenizer
@@ -12,13 +13,10 @@ class TrialsManager():
         self.block_name = block_name
         self.stim_configs = stim_configs
 
-        self.tokenizable = True
-        if self.stim_configs['type'] == 'continuous':
-            self.tokenizable = False
-            return
-
         stim_name = self.stim_configs['name']
-        if 'tone' in stim_name:
+        if self.stim_configs['type'] == 'continuous':
+            self.tokenizer = SingleTokenizer(self.block_name, self.stim_configs)
+        elif 'tone' in stim_name:
             self.tokenizer = ToneTokenizer(self.block_name, self.stim_configs)
         elif 'timit' in stim_name:
             self.tokenizer = TIMITTokenizer(self.block_name, self.stim_configs)
@@ -32,8 +30,6 @@ class TrialsManager():
             raise ValueError('self.custom_trial_columns should be set by the stim-specific tokenizer.')
 
     def add_trials(self, nwb_content, mark_onsets, stim_vals, mark_obj_name='recorded_mark'):
-        if not self.tokenizable:
-            return
         if self._already_tokenized(nwb_content):
             logger.info('Block has already been tokenized')
             return

--- a/nsds_lab_to_nwb/components/stimulus/trials_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/trials_manager.py
@@ -31,7 +31,7 @@ class TrialsManager():
         if self.custom_trial_columns is None:
             raise ValueError('self.custom_trial_columns should be set by the stim-specific tokenizer.')
 
-    def add_trials(self, nwb_content, mark_onsets, stim_vals, mark_name='recorded_mark'):
+    def add_trials(self, nwb_content, mark_onsets, stim_vals, mark_obj_name='recorded_mark'):
         if not self.tokenizable:
             return
         if self._already_tokenized(nwb_content):
@@ -39,7 +39,7 @@ class TrialsManager():
             return
 
         # tokenize to identify trials
-        mark_time_series = self.read_mark(nwb_content, mark_name=mark_name)
+        mark_time_series = self.read_mark(nwb_content, mark_obj_name)
         trial_list = self.tokenizer.tokenize(mark_onsets, mark_time_series, stim_vals)
 
         # add trial columns, then add trials
@@ -57,5 +57,5 @@ class TrialsManager():
                                     for column_args in self.custom_trial_columns)
         return all(has_custom_trial_columns)
 
-    def read_mark(self, nwb_content, mark_name='recorded_mark'):
-        return nwb_content.stimulus[mark_name]
+    def read_mark(self, nwb_content, mark_obj_name):
+        return nwb_content.stimulus[mark_obj_name]

--- a/nsds_lab_to_nwb/components/stimulus/trials_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/trials_manager.py
@@ -31,7 +31,7 @@ class TrialsManager():
         if self.custom_trial_columns is None:
             raise ValueError('self.custom_trial_columns should be set by the stim-specific tokenizer.')
 
-    def add_trials(self, nwb_content, stim_vals, mark_name='recorded_mark'):
+    def add_trials(self, nwb_content, mark_onsets, stim_vals, mark_name='recorded_mark'):
         if not self.tokenizable:
             return
         if self._already_tokenized(nwb_content):
@@ -40,7 +40,7 @@ class TrialsManager():
 
         # tokenize to identify trials
         mark_time_series = self.read_mark(nwb_content, mark_name=mark_name)
-        trial_list = self.tokenizer.tokenize(mark_time_series, stim_vals)
+        trial_list = self.tokenizer.tokenize(mark_onsets, mark_time_series, stim_vals)
 
         # add trial columns, then add trials
         for column_args in self.custom_trial_columns:

--- a/nsds_lab_to_nwb/components/stimulus/wav_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/wav_manager.py
@@ -17,8 +17,9 @@ class WavManager():
         self.stim_configs = stim_configs
 
     def get_stim_wav(self, starting_time, name='raw_stimulus'):
-        if self.stim_name in ('wn1', 'baseline'):
-            return None
+        # EDIT NOTE: this check is not necessary because get_stim_file handles missing audio_path
+        # if self.stim_name in ('wn1', 'baseline'):
+        #     return None
 
         stim_file = self.get_stim_file(self.stim_name, self.stim_lib_path)
         if stim_file is None:

--- a/nsds_lab_to_nwb/components/stimulus/wav_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/wav_manager.py
@@ -28,9 +28,9 @@ class WavManager():
             return None
 
         logger.debug(f'Loading stimulus from: {stim_file}')
-        return self._get_stim_wav(stim_file, starting_time, name=name)
+        return self._get_stim_wav(stim_file, starting_time, name)
 
-    def _get_stim_wav(self, stim_file, starting_time, name='raw_stimulus'):
+    def _get_stim_wav(self, stim_file, starting_time, name):
         ''' get the raw wav stimulus track '''
         # Read the stimulus wav file
         stim_wav_fs, stim_wav = wavfile.read(stim_file)
@@ -42,7 +42,7 @@ class WavManager():
                                       starting_time=starting_time,
                                       unit='Volts',
                                       rate=rate,
-                                      description='The neural recording aligned stimulus track.')
+                                      description='Auditory stimulus waveform, aligned to neural recording.')
         return stim_time_series
 
     @staticmethod

--- a/scripts/all_test_blocks_catscan.sh
+++ b/scripts/all_test_blocks_catscan.sh
@@ -20,8 +20,8 @@ BLOCK_LIST=("RVG16_B01"  # wn2
             "RVG16_B10"  # dmr
             "RVG21_B12"  # baseline stim
             "RVG21_B13"  # TIMIT
-            "R56_B10"
-            "R56_B13"
+            "R56_B10"    # tone, *legacy block*
+            "R56_B13"    # wn2, *legacy block*
             )
 
 for BLOCK_NAME in "${BLOCK_LIST[@]}"; do

--- a/tests/test_catscan.py
+++ b/tests/test_catscan.py
@@ -47,8 +47,8 @@ def test_nwb_builder(tmpdir, block_folder):
     nwb_builder.write(nwb_content)
 
 
-@pytest.mark.parametrize("block_folder", [("R56_B10"),
-                                          ("R56_B13")])
+@pytest.mark.parametrize("block_folder", [("R56_B10"),      # tone, *legacy block*
+                                          ("R56_B13")])     # wn2, *legacy block*
 def test_legacy_nwb_builder(tmpdir, block_folder):
     """Runs the NWB pipline on a block."""
     if not os.path.isdir(os.environ['NSDS_DATA_PATH']):


### PR DESCRIPTION
# Description and related issues

List of changes:
- use TDT-loaded mark onsets when available, instead of using mark thresholds (as discussed #102); this would resolve #76
- create a single trial for continuous stimuli (per discussion in issue #88)
    - add new class `SingleTokenizer` for this
- update name and description for mark and wav TimeSeries objects (related issue: #51)
    - (still open for discussion)

This PR would close 
- Close #51
- Close #76
- Close #88
- Close #102

# Checklist:

- [ ] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory
    - `test_catscan` passes on all test blocks with `resample_data=False`
    - larger blocks fail with `resample_data=True` (`RVG16_B06`, `RVG16_B07`, `RVG16_B10`, `RVG21_B13`, `R56_B10`)
- [x] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [x] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [x] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory
