### PR TITLE
Conversion resolution

### DIFF
--- a/nsds_lab_to_nwb/components/neural_data/neural_data_originator.py
+++ b/nsds_lab_to_nwb/components/neural_data/neural_data_originator.py
@@ -31,8 +31,6 @@ class NeuralDataOriginator():
 
             logger.info(f'Extracting {device_name} data...')
             data, metadata = self.neural_data_reader.get_data(stream=device_name, dev_conf=dev_conf)
-            conversion = f'tdt_{device_name.lower()}_conversion'
-            resolution = f'tdt_{device_name.lower()}_resolution'
             if data is None:
                 logger.info(f'No data available for {device_name}. Skipping...')
             else:
@@ -57,8 +55,8 @@ class NeuralDataOriginator():
                                             rate=self._get_rate(),
                                             description=description,
                                             comments=comments,
-                                            conversion=self.metadata[conversion],
-                                            resolution=self.metadata[resolution]
+                                            conversion=dev_conf.get('conversion', 1.),
+                                            resolution=dev_conf.get('resolution', 1.)
                                             )
                 logger.info(f'Adding {device_name} data to NWB...')
                 logger.debug(f' - Description: {description}')

--- a/nsds_lab_to_nwb/components/neural_data/neural_data_originator.py
+++ b/nsds_lab_to_nwb/components/neural_data/neural_data_originator.py
@@ -31,6 +31,8 @@ class NeuralDataOriginator():
 
             logger.info(f'Extracting {device_name} data...')
             data, metadata = self.neural_data_reader.get_data(stream=device_name, dev_conf=dev_conf)
+            conversion = f'tdt_{device_name.lower()}_conversion'
+            resolution = f'tdt_{device_name.lower()}_resolution'
             if data is None:
                 logger.info(f'No data available for {device_name}. Skipping...')
             else:
@@ -55,6 +57,8 @@ class NeuralDataOriginator():
                                             rate=self._get_rate(),
                                             description=description,
                                             comments=comments,
+                                            conversion=self.metadata[conversion],
+                                            resolution=self.metadata[resolution]
                                             )
                 logger.info(f'Adding {device_name} data to NWB...')
                 logger.debug(f' - Description: {description}')

--- a/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
+++ b/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
@@ -54,18 +54,20 @@ class StimValueExtractor():
 
 
 def tone_stimulus_values(mat_file_path):
-    ''' adapted from mars.configs.block_directory
+    """adapted from mars.configs.block_directory
 
-    Parameters:
-    -----------
-    mat_file_path: full path to a .mat file that contains stim_values.
+    Parameters
+    ----------
+    mat_file_path : path
+        full path to a .mat file that contains stim_values.
 
-    Returns:
-    --------
-    stim_vals: a 2D array with two columns (NOTE: changed from legacy behavior)
-        stim_vals[:, 0] are the amplitudes,
-        stim_vals[:, 1] are the frequencies of the tones.
-    '''
+    Returns
+    -------
+    stim_vals : ndarray (n, 2)
+        a 2D array with two columns (NOTE: changed from legacy behavior)
+        `stim_vals[:, 0]` are the amplitudes,
+        `stim_vals[:, 1]` are the frequencies of the tones.
+    """
     sio = read_mat_file(mat_file_path)
     stim_vals = sio['stimVls'][:].astype(int)
 
@@ -87,17 +89,17 @@ def tone_stimulus_values(mat_file_path):
 
 
 def timit_stimulus_values(file_path):
-    ''' adapted from mars.configs.block_directory
+    """adapted from mars.configs.block_directory
 
-    Parameters:
+    Parameters
     -----------
-    file_path: full path to a .txt file that contains a list of filenames
+    file_path : full path to a .txt file that contains a list of filenames
 
-    Returns:
+    Returns
     --------
-    stim_vals: a list of strings, where each item is a .wav file name in TIMIT.
-        (should confirm!)
-    '''
+    stim_vals: list of str
+        each item is a .wav file name in TIMIT. (should confirm!)
+    """
     _, ext = os.path.splitext(file_path)
     if not (ext == '.txt'):
         raise ValueError('for now only accepting a txt file that lists wav file names.')

--- a/nsds_lab_to_nwb/metadata/exp_note_reader.py
+++ b/nsds_lab_to_nwb/metadata/exp_note_reader.py
@@ -6,8 +6,8 @@ from nsds_lab_to_nwb.common.io import write_yaml
 
 # Default metadata values
 defaults = dict()
-defaults['tdt_wave_conversion'] = 1e-6
-defaults['tdt_wave_resolution'] = 1e-6
+defaults['tdt_ecog_conversion'] = 1e-6
+defaults['tdt_ecog_resolution'] = 1e-6
 defaults['tdt_poly_conversion'] = 1.
 defaults['tdt_poly_resolution'] = 1e-7
 

--- a/nsds_lab_to_nwb/metadata/exp_note_reader.py
+++ b/nsds_lab_to_nwb/metadata/exp_note_reader.py
@@ -4,6 +4,14 @@ from nsds_lab_to_nwb.utils import split_block_folder
 from nsds_lab_to_nwb.common.io import write_yaml
 
 
+# Default metadata values
+defaults = dict()
+defaults['tdt_wave_conversion'] = 1e-6
+defaults['tdt_wave_resolution'] = 1e-6
+defaults['tdt_poly_conversion'] = 1.
+defaults['tdt_poly_resolution'] = 1e-7
+
+
 class ExpNoteReader():
     """Class for parsing experiment notes
 
@@ -176,6 +184,9 @@ class ExpNoteReader():
         meta = self.meta_df.to_dict()
         meta.update(sub_block)
         self.nsds_meta = meta
+        for key in defaults.keys():
+            if key not in self.nsds_meta.keys():
+                self.nsds_meta[key] = defaults[key]
 
     def dump_yaml(self, write_path=None):
         """Dump yaml file

--- a/nsds_lab_to_nwb/metadata/exp_note_reader.py
+++ b/nsds_lab_to_nwb/metadata/exp_note_reader.py
@@ -4,14 +4,6 @@ from nsds_lab_to_nwb.utils import split_block_folder
 from nsds_lab_to_nwb.common.io import write_yaml
 
 
-# Default metadata values
-defaults = dict()
-defaults['tdt_ecog_conversion'] = 1e-6
-defaults['tdt_ecog_resolution'] = 1e-6
-defaults['tdt_poly_conversion'] = 1.
-defaults['tdt_poly_resolution'] = 1e-7
-
-
 class ExpNoteReader():
     """Class for parsing experiment notes
 
@@ -184,9 +176,6 @@ class ExpNoteReader():
         meta = self.meta_df.to_dict()
         meta.update(sub_block)
         self.nsds_meta = meta
-        for key in defaults.keys():
-            if key not in self.nsds_meta.keys():
-                self.nsds_meta[key] = defaults[key]
 
     def dump_yaml(self, write_path=None):
         """Dump yaml file

--- a/nsds_lab_to_nwb/metadata/metadata_manager.py
+++ b/nsds_lab_to_nwb/metadata/metadata_manager.py
@@ -16,6 +16,11 @@ from nsds_lab_to_nwb.metadata.stim_name_helper import check_stimulus_name
 
 
 _DEFAULT_EXPERIMENT_TYPE = 'auditory'
+_TDT_ECoG_CONVERSION = 1e-6
+_TDT_ECoG_RESOLUTION = 1e-6
+_TDT_Poly_CONVERSION = 1.
+_TDT_Poly_RESOLUTION = 1e-7
+
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -182,6 +187,24 @@ class MetadataReader:
             device_metadata.pop('Poly')
             block_meta.pop('poly_ap_loc', None)
             block_meta.pop('poly_dev_loc', None)
+
+        # Add conversion and resolution defaults if not there
+        if 'ECoG' in device_metadata.keys():
+            d = device_metadata['ECoG']
+            if 'ecog_conversion' not in d.keys():
+                if d['acq'] == 'TDT PZM5':
+                    d['conversion'] = _TDT_ECoG_CONVERSION
+            if 'ecog_resolution' not in d.keys():
+                if d['acq'] == 'TDT PZM5':
+                    d['resolution'] = _TDT_ECoG_RESOLUTION
+        if 'Poly' in device_metadata.keys():
+            d = device_metadata['Poly']
+            if 'poly_conversion' not in d.keys():
+                if d['acq'] == 'TDT PZM5':
+                    d['conversion'] = _TDT_ECoG_CONVERSION
+            if 'poly_resolution' not in d.keys():
+                if d['acq'] == 'TDT PZM5':
+                    d['resolution'] = _TDT_Poly_RESOLUTION
 
         # make extra_meta
         self.metadata_input['extra_meta'] = {}

--- a/nsds_lab_to_nwb/metadata/metadata_manager.py
+++ b/nsds_lab_to_nwb/metadata/metadata_manager.py
@@ -16,10 +16,10 @@ from nsds_lab_to_nwb.metadata.stim_name_helper import check_stimulus_name
 
 
 _DEFAULT_EXPERIMENT_TYPE = 'auditory'
-_TDT_ECoG_CONVERSION = 1e-6
-_TDT_ECoG_RESOLUTION = 1e-6
-_TDT_Poly_CONVERSION = 1.
-_TDT_Poly_RESOLUTION = 1e-7
+_TDT_ECoG_CONVERSION = '1e-6'
+_TDT_ECoG_RESOLUTION = '1e-6'
+_TDT_Poly_CONVERSION = '1.'
+_TDT_Poly_RESOLUTION = '1e-7'
 
 
 logger = logging.getLogger(__name__)
@@ -191,20 +191,20 @@ class MetadataReader:
         # Add conversion and resolution defaults if not there
         if 'ECoG' in device_metadata.keys():
             d = device_metadata['ECoG']
-            if 'ecog_conversion' not in d.keys():
+            if 'conversion' not in d.keys():
                 if d['acq'] == 'TDT PZM5':
                     d['conversion'] = _TDT_ECoG_CONVERSION
-            if 'ecog_resolution' not in d.keys():
+            if 'resolution' not in d.keys():
                 if d['acq'] == 'TDT PZM5':
-                    d['resolution'] = _TDT_ECoG_RESOLUTION
+                    d['resolution'] = _TDT_ECoG_CONVERSION
         if 'Poly' in device_metadata.keys():
             d = device_metadata['Poly']
-            if 'poly_conversion' not in d.keys():
+            if 'conversion' not in d.keys():
                 if d['acq'] == 'TDT PZM5':
-                    d['conversion'] = _TDT_ECoG_CONVERSION
-            if 'poly_resolution' not in d.keys():
+                    d['conversion'] =  _TDT_Poly_CONVERSION
+            if 'resolution' not in d.keys():
                 if d['acq'] == 'TDT PZM5':
-                    d['resolution'] = _TDT_Poly_RESOLUTION
+                    d['resolution'] = _TDT_Poly_CONVERSION
 
         # make extra_meta
         self.metadata_input['extra_meta'] = {}
@@ -512,6 +512,12 @@ class MetadataManager:
                 if isinstance(value, str):
                     device_metadata[key] = {'name': value}
                 dev_conf = device_metadata[key]
+                for float_attr in ['resolution', 'conversion']:
+                    try:
+                        dev_conf[float_attr] = float(dev_conf[float_attr])
+                    except KeyError:
+                        pass
+                        
                 probe_path = os.path.join(self.yaml_lib_path, 'probe', dev_conf['name'] + '.yaml')
                 dev_conf.update(read_yaml(probe_path))
 

--- a/nsds_lab_to_nwb/metadata/resources/metadata_keymap.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/metadata_keymap.yaml
@@ -194,6 +194,26 @@ keymap:
   mapto: device.Poly.bad_chs
   description: ''
 
+- name: ecog_conversion
+  comes_from: block_metadata
+  mapto: device.ECoG.conversion
+  description: ''
+
+- name: ecog_resolution
+  comes_from: block_metadata
+  mapto: device.ECoG.resolution
+  description: ''
+
+- name: poly_conversion
+  comes_from: block_metadata
+  mapto: device.Poly.conversion
+  description: ''
+
+- name: poly_resolution
+  comes_from: block_metadata
+  mapto: device.Poly.resolution
+  description: ''
+
 - name: clean_block
   comes_from: block_metadata
   mapto: block_meta.is_clean_block

--- a/tests/test_catscan.py
+++ b/tests/test_catscan.py
@@ -8,7 +8,7 @@ os.environ['NSDS_DATA_PATH'] = '/clusterfs/NSDS_data/raw/'
 os.environ['NSDS_METADATA_PATH'] = '/clusterfs/NSDS_data/NSDSLab-NWB-metadata/'
 os.environ['NSDS_STIMULI_PATH'] = '/clusterfs/NSDS_data/stimuli/'
 
-RESAMPLE_DATA = True
+RESAMPLE_DATA = False
 
 
 @pytest.mark.parametrize("block_folder", [("RVG16_B01"),  # wn2


### PR DESCRIPTION
# Description and related issues
Adds conversion and resolution default parameters. Tested on blocks that don't have these parameters in the spreadsheet. Still need to test it in a block with the fields in the spreadsheet.

Works on RVG26 which has these parameters.

Please include a summary of the changes and any issues which are addressed.

Closes #117 #116 

# Checklist:

- [x] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory
I think no new tests fail, although it seems like a bunch of the tests currently fail on main.
- [x] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [x] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [x] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory
