### PR TITLE
Fixed no space bug

### DIFF
--- a/nsds_lab_to_nwb/metadata/metadata_manager.py
+++ b/nsds_lab_to_nwb/metadata/metadata_manager.py
@@ -143,8 +143,10 @@ class MetadataReader:
 
         if isinstance(bad_chs, str):
             logger.info(' - Trying to interpret the str...')
-            # assume that this string has a list of integers separated by commas and spaces
-            bad_chs_list_strings = bad_chs.split(', ')
+            # assume that this string has a list of integers separated by commas
+            str_split = bad_chs.split(',')
+            # remove spaces between commas
+            bad_chs_list_strings = [x.strip() for x in str_split]
             try:
                 bad_chs = [int(ch) for ch in bad_chs_list_strings]
                 logger.info(' - Converted to a list of integers.')
@@ -206,7 +208,7 @@ class MetadataReader:
             d = device_metadata['Poly']
             if 'conversion' not in d.keys():
                 if d['acq'] == 'TDT PZM5':
-                    d['conversion'] =  _TDT_Poly_CONVERSION
+                    d['conversion'] = _TDT_Poly_CONVERSION
             if 'resolution' not in d.keys():
                 if d['acq'] == 'TDT PZM5':
                     d['resolution'] = _TDT_Poly_CONVERSION
@@ -524,7 +526,7 @@ class MetadataManager:
                         dev_conf[float_attr] = float(dev_conf[float_attr])
                     except KeyError:
                         pass
-                        
+
                 probe_path = os.path.join(self.yaml_lib_path, 'probe', dev_conf['name'] + '.yaml')
                 dev_conf.update(read_yaml(probe_path))
 


### PR DESCRIPTION
# Description and related issues
This should fix these errors:
`Unable to interpret bad_chs as a list. Check your metadata input and review the yaml syntax for storing a list.`

Please include a summary of the changes and any issues which are addressed.
- Parses comma separated lists with or without spaces
- Formatting tweaks in metadata_manager

Closes #(issue number)

# Checklist:

- [~] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory (tested locally on John's PC)
- [x] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [x] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [x] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory
