### PR TITLE
(WIP) Removes using TDT marks

### DIFF
--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/base_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/base_tokenizer.py
@@ -31,10 +31,11 @@ class BaseTokenizer():
         raise NotImplementedError
 
     def get_stim_onsets(self, mark_onsets, mark_time_series):
-        if mark_onsets is not None:
-            # loaded directly from TDT object
-            logger.info('Using stimulus onsets directly loaded from TDT')
-            return mark_onsets
+        # This ignore mark offset from metadata!
+        # if mark_onsets is not None:
+        #     # loaded directly from TDT object
+        #     logger.info('Using stimulus onsets directly loaded from TDT')
+        #     return mark_onsets
 
         logger.info('Detecting stimulus onsets by thresholding the mark track')
         mark_fs = mark_time_series.rate


### PR DESCRIPTION
# Description and related issues
Currently if TDT has marks, base_tokenizers ignores meta data and assumes marks are correct. To resolve this, I commented out the code that looks for TDT marks and instead always parses the marks time series for marks and then adds offset referenced in meta data.

This is a WIP because it does not pass tests on catscan. I'm not sure if these are actual failures or if my catscan environment is not setup correctly.

Closes #122 

# Checklist:

- [ ] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory
- [x] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [ ] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [ ] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory
