### PR TITLE
[WIP] improvements to tdt reading and nwb saving

### DIFF
--- a/nsds_lab_to_nwb/components/stimulus/mark_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/mark_manager.py
@@ -1,4 +1,5 @@
 from pynwb import TimeSeries
+from hdmf.backends.hdf5.h5_utils import H5DataIO
 
 from nsds_lab_to_nwb.tools.htk.readers.htkfile import HTKFile
 from nsds_lab_to_nwb.tools.tdt.tdt_reader import TDTReader
@@ -8,7 +9,7 @@ class MarkManager():
     def __init__(self, dataset):
         self.dataset = dataset
 
-    def get_mark_track(self, starting_time, name='recorded_mark'):
+    def get_mark_track(self, starting_time, name='recorded_mark', tdt_reader=None):
         # Read the mark track
         if hasattr(self.dataset, 'htk_mark_path'):
             mark_file = HTKFile(self.dataset.htk_mark_path)
@@ -16,7 +17,8 @@ class MarkManager():
             rate = mark_file.sample_rate
             mark_onsets = None
         else:
-            tdt_reader = TDTReader(self.dataset.tdt_path)
+            if tdt_reader is None:
+                tdt_reader = TDTReader(self.dataset.tdt_path)
             mark_track, meta = tdt_reader.get_data(stream='mrk1')
             rate = meta['sample_rate']
             try:
@@ -27,7 +29,10 @@ class MarkManager():
 
         # Create the mark timeseries
         mark_time_series = TimeSeries(name=name,
-                                      data=mark_track,
+                                      data=H5DataIO(mark_track,
+                                                    compression=True,
+                                                    shuffle=True,
+                                                    fletcher32=True),
                                       unit='Volts',
                                       starting_time=starting_time,
                                       rate=rate,

--- a/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
+++ b/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
@@ -30,7 +30,7 @@ class StimulusOriginator():
         self.mark_obj_name = 'stim_onset_marks'  # 'recorded_mark' (previous name)
         self.stim_wav_obj_name = 'stim_waveform'  # 'raw_stimulus' (previous name)
 
-    def make(self, nwb_content):
+    def make(self, nwb_content, tdt_reader=None):
         stim_name = self.stim_configs['name']
         stim_type = self.stim_configs['type']  # either 'discrete' or 'continuous'
         logger.info(f'Stimulus name: {stim_name} (type: {stim_type})')
@@ -39,7 +39,8 @@ class StimulusOriginator():
         logger.info('Adding marks...')
         mark_starting_time = 0.0    # see issue #88 for discussion
         mark_time_series, mark_onsets = self.mark_manager.get_mark_track(starting_time=mark_starting_time,
-                                                                         name=self.mark_obj_name)
+                                                                         name=self.mark_obj_name,
+                                                                         tdt_reader=tdt_reader)
         nwb_content.add_stimulus(mark_time_series)
 
         # tokenize into trials, once mark track has been added to nwb_content

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/base_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/base_tokenizer.py
@@ -31,10 +31,12 @@ class BaseTokenizer():
         raise NotImplementedError
 
     def get_stim_onsets(self, mark_onsets, mark_time_series):
+        """
         if mark_onsets is not None:
             # loaded directly from TDT object
             logger.info('Using stimulus onsets directly loaded from TDT')
             return mark_onsets
+            """
 
         logger.info('Detecting stimulus onsets by thresholding the mark track')
         mark_fs = mark_time_series.rate

--- a/nsds_lab_to_nwb/components/stimulus/wav_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/wav_manager.py
@@ -3,6 +3,7 @@ import os
 from scipy.io import wavfile
 
 from pynwb import TimeSeries
+from hdmf.backends.hdf5.h5_utils import H5DataIO
 
 from nsds_lab_to_nwb.metadata.stim_name_helper import check_stimulus_name
 from nsds_lab_to_nwb.utils import get_stim_lib_path
@@ -38,7 +39,10 @@ class WavManager():
 
         # Create the stimulus timeseries
         stim_time_series = TimeSeries(name=name,
-                                      data=stim_wav,
+                                      data=H5DataIO(stim_wav,
+                                                    compression=True,
+                                                    shuffle=True,
+                                                    fletcher32=True),
                                       starting_time=starting_time,
                                       unit='Volts',
                                       rate=rate,

--- a/nsds_lab_to_nwb/nwb_builder.py
+++ b/nsds_lab_to_nwb/nwb_builder.py
@@ -97,9 +97,9 @@ class NWBBuilder:
 
         logger.info('Creating originator instances...')
         self.electrodes_originator = ElectrodesOriginator(self.metadata)
+        self.stimulus_originator = StimulusOriginator(self.dataset, self.metadata)
         self.neural_data_originator = NeuralDataOriginator(self.dataset, self.metadata,
                                                            resample_flag=self.resample_data)
-        self.stimulus_originator = StimulusOriginator(self.dataset, self.metadata)
 
         logger.info('Extracting session start time...')
         self.session_start_time = self._extract_session_start_time()
@@ -172,7 +172,7 @@ class NWBBuilder:
             return get_default_time()
 
         # extract from TDT data
-        recorded_metadata = self.neural_data_originator.neural_data_reader.tdt_obj['info']
+        recorded_metadata = self.neural_data_originator.neural_data_reader.get_info()
         session_start_time = recorded_metadata['start_date']
         return validate_time(session_start_time)
 
@@ -235,13 +235,14 @@ class NWBBuilder:
         electrode_table_regions = self.electrodes_originator.make(nwb_content)
 
         logger.info('Adding neural data...')
-        self.neural_data_originator.make(nwb_content, electrode_table_regions)
+        tdt_reader = self.neural_data_originator.make(nwb_content, electrode_table_regions)
 
         if process_stim:
             logger.info('Adding stimulus...')
-            self.stimulus_originator.make(nwb_content)
+            self.stimulus_originator.make(nwb_content, tdt_reader=tdt_reader)
         else:
             logger.info('Skipping stimulus...')
+
 
         logger.info('NWB content built successfully.')
         return nwb_content

--- a/nsds_lab_to_nwb/tools/tdt/tdt_reader.py
+++ b/nsds_lab_to_nwb/tools/tdt/tdt_reader.py
@@ -20,17 +20,25 @@ class TDTReader:
     def __init__(self, path, channels=None):
         self.path = path
         self.channels = channels
+        self.tdt_obj = None
+        self.nodata = True
 
-        if channels is None:
-            self.tdt_obj = tdt.read_block(path)
-        else:
-            self.tdt_obj = tdt.read_block(path, channel=channels)
+    def _lazy_init(self, nodata=False):
+        if (self.tdt_obj is None) or (not nodata and self.nodata):
+            evtype = ['scalars', 'epocs']
+            if (not nodata and self.nodata):
+                evtype = ['all']
+                self.nodata = False
+            if self.channels is None:
+                self.tdt_obj = tdt.read_block(self.path, evtype=evtype)
+            else:
+                self.tdt_obj = tdt.read_block(self.path, channel=self.channels, evtype=evtype)
 
-        self.streams = self.get_streams()
-        self.block_name = self.tdt_obj['info']['blockname']
-        self.start_time = self.tdt_obj['info']['utc_start_time']
+            self.streams = self.get_streams()
+            self.block_name = self.tdt_obj['info']['blockname']
+            self.start_time = self.tdt_obj['info']['utc_start_time']
 
-        logger.debug('Streams: ' + ', '.join(self.streams))
+            logger.debug('Streams: ' + ', '.join(self.streams))
 
     def get_streams(self):
         """Get TDT all stream names
@@ -38,6 +46,7 @@ class TDTReader:
         Returns:
             streams (list): stream names
         """
+        self._lazy_init()
         streams = list(self.tdt_obj['streams'].keys())
         return streams
 
@@ -50,6 +59,7 @@ class TDTReader:
         Returns:
             meta (dict): dictionary containing stream recording parameters (if no stream returns None)
         """
+        self._lazy_init(nodata=True)
         stream = self.check_stream(stream)
         meta = {}
         meta['sample_rate'] = self.tdt_obj['streams'][stream]['fs']
@@ -61,6 +71,18 @@ class TDTReader:
             meta['num_channels'] = 1
         else:
             meta['num_channels'], meta['num_samples'] = data_shape
+        return meta
+
+    def get_info(self):
+        """Get general metadata
+
+        Returns:
+            meta (dict): dictionary containing recording parameters
+        """
+        self._lazy_init(nodata=True)
+        meta = {}
+        meta['start_time'] = self.tdt_obj['info']['utc_start_time']
+        meta['start_date'] = self.tdt_obj['info']['start_date']
         return meta
 
     def check_stream(self, stream):
@@ -76,6 +98,7 @@ class TDTReader:
         stream: str
             Stream name updated to the standard name if an alternative was used.
         """
+        self._lazy_init()
         error_message = f"Device or stream '{stream}' not found. Available streams: ["
         error_message += ", ".join(self.streams)
         error_message += "]"
@@ -103,6 +126,7 @@ class TDTReader:
         meta: dict
             Meta data for the data array.
         """
+        self._lazy_init()
         stream = self.check_stream(stream)
         data = self.tdt_obj['streams'][stream]['data'].T
         meta = self.get_metadata(stream)
@@ -114,5 +138,6 @@ class TDTReader:
         Returns:
             events (list): list of samples where an event occured
         """
+        self._lazy_init(nodata=True)
         events = self.tdt_obj['epocs']['mark']['onset']
         return events


### PR DESCRIPTION
# Description and related issues

Calling `tdt.read_block()` by default loads all data. This can be very slow if you just need some metadata and not all of the neural data. Relatedly, creating multiple TDTReader objects across classes will mean that all of the data gets loaded every time it is used, even if you only need the mark track.

This PR makes the `TDTReader` somewhat lazy, changes the order of things in the NWBBuilder so wait until the last step to load any neural/mark data (makes debugging faster if metadata steps fail), and compresses the timeseries data which makes files 50-80% of their original size (should also make saving/loading faster, but need to test that).

# Checklist:

- [ ] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory
- [ ] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [ ] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [ ] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory
