### PR TITLE
Fix TIMIT tokenization

### DIFF
--- a/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
+++ b/nsds_lab_to_nwb/components/stimulus/stim_value_extractor.py
@@ -106,7 +106,8 @@ def timit_stimulus_values(file_path):
 
     # expecting a text file, one .wav filename string per row
     with open(file_path) as f:
-        stim_vals = f.readlines()
+        lines = f.readlines()
+    stim_vals = [line.rstrip(' \n') for line in lines]
     return stim_vals
 
 

--- a/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
+++ b/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
@@ -45,6 +45,7 @@ class StimulusOriginator():
         # tokenize into trials, once mark track has been added to nwb_content
         logger.info('Tokenizing into trials...')
         self.trials_manager.add_trials(nwb_content, mark_onsets, self.stim_vals,
+                                       audio_play_length=self.wav_manager.length,
                                        mark_obj_name=self.mark_obj_name)
 
         # add stimulus WAV data

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/base_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/base_tokenizer.py
@@ -15,7 +15,10 @@ class BaseTokenizer():
         self.tokenizer_type = 'BaseTokenizer'
         self.custom_trial_columns = None
 
-    def tokenize(self, mark_onsets, mark_time_series, stim_vals):
+    def tokenize(self, mark_onsets, mark_time_series, stim_vals,
+                 audio_play_length=None):
+        ''' audio_play_length: length of raw audio file. added for TIMIT
+        '''
         stim_onsets = self.get_stim_onsets(mark_onsets, mark_time_series)
         self._validate_num_stim_onsets(stim_vals, stim_onsets)
         rec_end_time = mark_time_series.num_samples / mark_time_series.rate
@@ -23,6 +26,7 @@ class BaseTokenizer():
                                     stim_dur=self.stim_configs['duration'],
                                     bl_start=self.stim_configs['baseline_start'],
                                     bl_end=self.stim_configs['baseline_end'],
+                                    audio_play_length=audio_play_length,
                                     rec_end_time=rec_end_time)
         return trial_list
 

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/single_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/single_tokenizer.py
@@ -20,7 +20,7 @@ class SingleTokenizer(BaseTokenizer):
                                     rec_end_time=rec_end_time)
         return trial_list
 
-    def _tokenize(self, stim_vals, stim_onsets, *, rec_end_time):
+    def _tokenize(self, stim_vals, stim_onsets, *, rec_end_time, **unused_metadata):
         stim_name = self.stim_configs['name']
         if stim_name == 'baseline':
             sb = 'b'

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/timit_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/timit_tokenizer.py
@@ -18,26 +18,32 @@ class TIMITTokenizer(BaseTokenizer):
 
     def _tokenize(self, stim_vals, stim_onsets,
                   *, audio_play_length, rec_end_time, **unused_metadata):
+        first_mark = self.stim_configs['first_mark']
+        audio_end_time = (stim_onsets[0] - first_mark) + audio_play_length
+
         trial_list = []
 
         # Add the pre-stimulus period to baseline
         trial_list.append(dict(start_time=0.0,
-                               stop_time=(stim_onsets[0] - stim_dur),
+                               stop_time=stim_onsets[0],
                                sb='b',
-                               sample_filename=stim_vals[0]))
+                               sample_filename='none'))
 
         for i, onset in enumerate(stim_onsets):
             filename = str(stim_vals[i])
+            try:
+                stop_time = stim_onsets[i + 1]
+            except IndexError:
+                stop_time = audio_end_time
             trial_list.append(dict(start_time=onset,
-                                   stop_time=(onset + stim_dur),
+                                   stop_time=stop_time,
                                    sb='s',
                                    sample_filename=filename))
-            # trial_list.append(dict(start_time=onset+bl_start, stop_time=onset+bl_end, sb='b',frq=frq,amp=amp))
 
-        # Add the period after the last stimulus to  baseline
-        trial_list.append(dict(start_time=(stim_onsets[-1] + bl_end),
+        # Add the period after the last stimulus to baseline
+        trial_list.append(dict(start_time=audio_end_time,
                                stop_time=rec_end_time,
                                sb='b',
-                               sample_filename=stim_vals[-1]))
+                               sample_filename='none'))
 
         return trial_list

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/timit_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/timit_tokenizer.py
@@ -17,7 +17,7 @@ class TIMITTokenizer(BaseTokenizer):
                                      ('sample_filename', 'Sample Filename')]
 
     def _tokenize(self, stim_vals, stim_onsets,
-                  *, stim_dur, bl_start, bl_end, rec_end_time):
+                  *, audio_play_length, rec_end_time, **unused_metadata):
         trial_list = []
 
         # Add the pre-stimulus period to baseline

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/tone_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/tone_tokenizer.py
@@ -18,7 +18,7 @@ class ToneTokenizer(BaseTokenizer):
                                      ('amp', 'Stimulus Amplitude')]
 
     def _tokenize(self, stim_vals, stim_onsets,
-                  *, stim_dur, bl_start, bl_end, rec_end_time):
+                  *, stim_dur, bl_start, bl_end, rec_end_time, **unused_metadata):
         trial_list = []
 
         # Add the pre-stimulus period to baseline

--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/wn_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/wn_tokenizer.py
@@ -22,7 +22,7 @@ class WNTokenizer(BaseTokenizer):
         self.custom_trial_columns = [('sb', 'Stimulus (s) or baseline (b) period')]
 
     def _tokenize(self, stim_vals, stim_onsets,
-                  *, stim_dur, bl_start, bl_end, rec_end_time):
+                  *, stim_dur, bl_start, bl_end, rec_end_time, **unused_metadata):
         """
         (caveat: docstring is outdated)
 

--- a/nsds_lab_to_nwb/components/stimulus/trials_manager.py
+++ b/nsds_lab_to_nwb/components/stimulus/trials_manager.py
@@ -29,14 +29,16 @@ class TrialsManager():
         if self.custom_trial_columns is None:
             raise ValueError('self.custom_trial_columns should be set by the stim-specific tokenizer.')
 
-    def add_trials(self, nwb_content, mark_onsets, stim_vals, mark_obj_name='recorded_mark'):
+    def add_trials(self, nwb_content, mark_onsets, stim_vals,
+                   *, audio_play_length, mark_obj_name='recorded_mark'):
         if self._already_tokenized(nwb_content):
             logger.info('Block has already been tokenized')
             return
 
         # tokenize to identify trials
         mark_time_series = self.read_mark(nwb_content, mark_obj_name)
-        trial_list = self.tokenizer.tokenize(mark_onsets, mark_time_series, stim_vals)
+        trial_list = self.tokenizer.tokenize(mark_onsets, mark_time_series, stim_vals,
+                                             audio_play_length=audio_play_length)
 
         # add trial columns, then add trials
         for column_args in self.custom_trial_columns:


### PR DESCRIPTION
# Description and related issues

This PR fixes TIMIT tokenization, and
- closes #125  .

## changed behavior

Now the trials table for `R73_B6` would look like the following.

start_time | stop_time | sb | sample_filename
-- | -- | -- | --
0.000000 | 15.407268 | b | none
15.407268 | 17.463173 | s | fmah0_si1289.Pshft.wav
17.463173 | 19.506340 | s | mrds0_si1167.Pshft.wav
19.506340 | 20.986266 | s | fceg0_si1878.Pshft.wav
20.986266 | 23.202202 | s | msjs1_si639.Pshft.wav
... | ... | ... | ...
2250.486456 | 2252.132762 | s | fsdc0_si2234.Pshft.wav
2252.132762 | 2254.777467 | s | mrab0_si1224.Pshft.wav
2254.777467 | 2257.082900 | s | mgaf0_si652.Pshft.wav
2257.082900 | 2259.079330 | s | frjb0_si1794.Pshft.wav
2259.079330 | 2281.533604 | b | none

<p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none; box-sizing: unset; margin: 0px 0px 1em; text-align: left; color: rgb(255, 255, 255); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;; font-size: 14px; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(17, 17, 17); text-decoration-thickness: initial;">1000 rows × 4 columns</p>

Some notes:

- There are 1000 trials, with 998 stimulus "s" trials, and two baseline "b" trials at the beginning and at the end.
- The stop-time for a previous trial is always the same as the start-time for the next trial. In practice, each "s" trial has 0.2s silence at the end (gap between adjacent stimuli). Once we confirm that this 0.2s was indeed programmed into the wav file, we could set each trial to end 0.2s early ... although this is a minor issue.
- The start-time for the first "s" trial (in this case 15.4s) is 5 seconds after the audio file is played. (This 5s corresponds to the `first_mark` in the stimulus metadata `timit.yaml` file)
- The stop-time for the last "s" trial is the time when the audio file ended.



# Checklist:

Didn't run through tests, but this successfully creates NWB files for `R73_B6` and `RVG06_B08` (both TIMIT blocks), with correct trials tables as shown above.

- [ ] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory
- [ ] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [ ] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [ ] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory
