### PR TITLE
fix timit and dmr baseline

### DIFF
--- a/nsds_lab_to_nwb/components/stimulus/tokenizers/single_tokenizer.py
+++ b/nsds_lab_to_nwb/components/stimulus/tokenizers/single_tokenizer.py
@@ -39,16 +39,25 @@ class SingleTokenizer(BaseTokenizer):
 
         # -- in case of continuous stimulus, such as DMR --
         stim_start_time = stim_onsets[0]
-        bl_start = self.stim_configs['baseline_start']
+
+        # bl_gap: gap between baseline and stimulus periods
+        # (use the same value for both the pre- and post-stim baselines)
+        bl_gap = self.stim_configs['baseline_start']
+        if self.stim_configs.get('baseline_end', None) is not None:
+            raise ValueError('baseline_end is assumed to have null/None value, '
+                             'meaning that baselines extend to the ends of recoding')
+
         back_pad = self.stim_configs.get('back_pad', 0.0)   # for DMR stimulus
 
         trial_list = []
 
         # add pre-stimulus period to baseline
-        trial_list.append(dict(start_time=0.0,
-                               stop_time=stim_start_time,
-                               sb='b',
-                               stim_name=''))
+        stop_time = stim_start_time - bl_gap
+        if stop_time > 0.0:
+            trial_list.append(dict(start_time=0.0,
+                                   stop_time=stop_time,
+                                   sb='b',
+                                   stim_name=''))
 
         # add single trial with continuous stimulus
         stim_stop_time = audio_end_time - back_pad
@@ -58,7 +67,7 @@ class SingleTokenizer(BaseTokenizer):
                                stim_name=stim_name))
 
         # add post-stimulus period to baseline
-        start_time = stim_stop_time + bl_start
+        start_time = stim_stop_time + bl_gap
         if start_time < rec_end_time:
             trial_list.append(dict(start_time=start_time,
                                    stop_time=rec_end_time,

--- a/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
+++ b/nsds_lab_to_nwb/metadata/resources/list_of_stimuli.yaml
@@ -18,9 +18,12 @@
 #       baseline_start: start of each in-trial baseline period, in seconds.
 #           relative to stimulus onset (for tone and wn stimuli)
 #           or relative to the end of last stimulus trial (timit and dmr).
+#           For timit and dmr, this value is also used to set a gap before
+#           the first stimulus onset.
 #       baseline_end: end of each in-trial baseline period, in seconds,
 #           relative to stimulus onset (for tone and wn stimuli).
-#           if null, last baseline extends to the end of recording (timit/dmr).
+#           If null (timit/dmr), last baseline extends to the end of recording,
+#           and initial baseline extends to the beginning of recording.
 #       first_mark: time from start of audio file to the first mark, in seconds.
 #       back_pad: time from end-of-stim to end-of-audio-file, in seconds (dmr only).
 #       mark_offset: time from mark to actual stimulus onset, in seconds.


### PR DESCRIPTION
# Description and related issues

For TIMIT and DMR trialization, add a gap of 3s between the initial baseline and the first stimulus onset.

There was already a gap of 3s between the end of stimulus and the final baseline.

Both values are controlled by the metadata item `baseline_start`.

- Closes #131 
