### PR TITLE
Removed metadata yaml write dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - h5py
   - hdmf
   - hdf5
-  - pynwb
+  - pynwb>=1.5.1
   - pyyaml
   - imageio
   - pytest

--- a/nsds_lab_to_nwb/common/io.py
+++ b/nsds_lab_to_nwb/common/io.py
@@ -5,6 +5,10 @@ import csv
 import h5py
 import scipy.io
 from collections import OrderedDict
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 # --- yaml ---
@@ -20,11 +24,14 @@ def write_yaml(yml_path, data, access_mode='w', default_flow_style=False, sort_k
     od_representer = (lambda dumper, data:
                       dumper.represent_mapping('tag:yaml.org,2002:map', data.items()))
     yaml.add_representer(OrderedDict, od_representer)
-    with io.open(yml_path, access_mode) as fh:
-        yaml.dump(data, fh,
-                  Dumper=MyDumper,
-                  default_flow_style=default_flow_style,
-                  sort_keys=sort_keys)
+    try:
+        with io.open(yml_path, access_mode) as fh:
+            yaml.dump(data, fh,
+                      Dumper=MyDumper,
+                      default_flow_style=default_flow_style,
+                      sort_keys=sort_keys)
+    except PermissionError:
+        logger.debug(f'Failed to write yaml due to permissions error in {yml_path}')
 
 
 def read_yaml(file_path):

--- a/nsds_lab_to_nwb/metadata/metadata_manager.py
+++ b/nsds_lab_to_nwb/metadata/metadata_manager.py
@@ -59,18 +59,14 @@ class MetadataReader:
         return self.metadata_input
 
     def load_metadata_source(self):
-        try:
-            metadata_input = read_yaml(self.block_metadata_path)
-        except FileNotFoundError:
-            # first generate the block metadata file
-            block_path_full, block_metadata_file = os.path.split(self.block_metadata_path)
-            experiment_path, _ = os.path.split(block_path_full)
-            block_folder, ext = os.path.splitext(block_metadata_file)
-            logger.debug(f'Looking for an experiment note file in {experiment_path}...')
-            reader = ExpNoteReader(experiment_path, block_folder)
-            reader.dump_yaml(write_path=self.block_metadata_path)
-            # then try reading again
-            metadata_input = read_yaml(self.block_metadata_path)
+        # first generate the block metadata file
+        block_path_full, block_metadata_file = os.path.split(self.block_metadata_path)
+        experiment_path, _ = os.path.split(block_path_full)
+        block_folder, ext = os.path.splitext(block_metadata_file)
+        logger.debug(f'Looking for an experiment note file in {experiment_path}...')
+        reader = ExpNoteReader(experiment_path, block_folder)
+        reader.dump_yaml(write_path=self.block_metadata_path)
+        metadata_input = reader.get_nsds_meta()
         return metadata_input
 
     def parse(self):
@@ -265,6 +261,7 @@ class LegacyMetadataReader(MetadataReader):
         # TODO: separate (experiment, device) metadata library as legacy
         self.legacy_lib_path = os.path.join(self.metadata_lib_path, self.experiment_type, 'legacy')
 
+    
     def load_metadata_source(self):
         # direct input from the block yaml file (not yet expanded)
         metadata_input = read_yaml(self.block_metadata_path)


### PR DESCRIPTION
# Description and related issues
- Changes metadata reading behavior to always read from ods (or whatever the native experiment notes file is in). Removes reading metadata yaml requirement
- Attempts to write metadata yaml, but catches PermissionError and logs it


Please include a summary of the changes and any issues which are addressed.

Closes #(issue number)
#132 

# Checklist:

- [ ] All tests pass on catscan: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory
- [x] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [x] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [x] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory
