### PR TITLE
add wrapper function get_stimulus_metadata

### DIFF
--- a/nsds_lab_to_nwb/metadata/__init__.py
+++ b/nsds_lab_to_nwb/metadata/__init__.py
@@ -1,0 +1,1 @@
+from .stim_name_helper import get_stimulus_metadata

--- a/nsds_lab_to_nwb/metadata/stim_name_helper.py
+++ b/nsds_lab_to_nwb/metadata/stim_name_helper.py
@@ -13,3 +13,8 @@ def check_stimulus_name(stim_name_input):
             if stim_name_input == alt_name:
                 return key, stim_info
     raise ValueError(f"Stimulus type '{stim_name_input}' not found.")
+
+
+def get_stimulus_metadata(stim_name_input):
+    _, stim_info = check_stimulus_name(stim_name_input)
+    return stim_info


### PR DESCRIPTION
does not change any existing behavior.

for easy access to stimulus audio paths, etc., in analysis.