### PR TITLE
standardize stim name into session_description

### DIFF
--- a/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
+++ b/nsds_lab_to_nwb/components/stimulus/stimulus_originator.py
@@ -28,7 +28,6 @@ class StimulusOriginator():
                                             self.stim_configs)
 
     def _get_stim_parameter_path(self):
-        stim_name = self.stim_configs['name']
         parameter_path = self.stim_configs['parameter_path']
         if parameter_path is None or len(parameter_path) == 0:
             return None

--- a/nsds_lab_to_nwb/metadata/__init__.py
+++ b/nsds_lab_to_nwb/metadata/__init__.py
@@ -1,1 +1,3 @@
 from .stim_name_helper import get_stimulus_metadata
+
+__all__ = ['get_stimulus_metadata']

--- a/nsds_lab_to_nwb/metadata/metadata_manager.py
+++ b/nsds_lab_to_nwb/metadata/metadata_manager.py
@@ -347,10 +347,7 @@ class LegacyMetadataReader(MetadataReader):
         # final touches...
         if self.experiment_type == 'auditory':
             self.metadata_input['experiment_description'] = 'Auditory experiment'
-        if ('session_description' not in self.metadata_input
-                or len(self.metadata_input['session_description']) == 0):
-            self.metadata_input['session_description'] = (
-                'Auditory experiment with {} stimulus'.format(self.metadata_input['stimulus']['name']))
+        self.metadata_input['session_description'] = check_stimulus_name(self.metadata_input['stimulus']['name'])
 
     def __add_old_experiment_notes(self):
         notes = self.metadata_input['notes'].strip(' ')

--- a/nsds_lab_to_nwb/metadata/metadata_manager.py
+++ b/nsds_lab_to_nwb/metadata/metadata_manager.py
@@ -261,7 +261,6 @@ class LegacyMetadataReader(MetadataReader):
         # TODO: separate (experiment, device) metadata library as legacy
         self.legacy_lib_path = os.path.join(self.metadata_lib_path, self.experiment_type, 'legacy')
 
-    
     def load_metadata_source(self):
         # direct input from the block yaml file (not yet expanded)
         metadata_input = read_yaml(self.block_metadata_path)


### PR DESCRIPTION
# Description and related issues

Normalizes the stimulus name which is saved as `session_description` in the NWBFile.

Closes #137

# Checklist:

- [x] Catscan tests pass: run `pytest --basetemp=tmp -sv -n 8 tests` on catscan from the root directory
- [ ] If needed, docs have been update: `docs/source` has been updated for any added, moved, or removed files
- [x] Docs build with no errors: run `make clean & make html` from the `docs` folder
- [x] No python formatting errors: run `flake8 nsds_lab_to_nwb tests` from the root directory
